### PR TITLE
No wraps in the first security-issue table column

### DIFF
--- a/components/security-issues/SecurityIssuesTable.tsx
+++ b/components/security-issues/SecurityIssuesTable.tsx
@@ -91,7 +91,7 @@ export const SecurityIssuesTable: FC<{
                   );
                 }}
               >
-                <td className="px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
+                <td className="px-6 py-4 text-sm text-gray-900 dark:text-gray-100 text-nowrap">
                   {issue.issueNumber}
                 </td>
 


### PR DESCRIPTION
Quick change to the KSI page: Added an extra `text-nowrap` class to the first-column `td`s, to counteract random wrapping:

![image](https://github.com/user-attachments/assets/3b80780b-2350-4e1e-9049-6585dfd10d7f)


After:

![image](https://github.com/user-attachments/assets/826bc074-f7c1-43ec-b13f-428ac94c6cf8)
