### PR TITLE
Changelog overhaul plus All Releases fix

### DIFF
--- a/components/releases/AllReleases.js
+++ b/components/releases/AllReleases.js
@@ -50,7 +50,6 @@ export default function AllReleases({ sideNav, slug }) {
     };
 
     return (
-        <>
             <div className="max-w-[1400px] mx-auto flex">
                 <main className="flex-1 min-w-0 pt-8 px-12
                     [&::-webkit-scrollbar]:w-1.5
@@ -86,7 +85,7 @@ export default function AllReleases({ sideNav, slug }) {
                                             : "bg-muted hover:bg-muted/80"
                                     }`}
                                 >
-                                    Agile
+                                    Current
                                 </button>
                                 <button
                                     onClick={() => handleVersionToggle(FilterReleases.LTS)}
@@ -119,6 +118,5 @@ export default function AllReleases({ sideNav, slug }) {
                     </div>
                 </main>
             </div>
-        </>
     );
 }

--- a/components/releases/TableReleases/TableReleases.tsx
+++ b/components/releases/TableReleases/TableReleases.tsx
@@ -36,7 +36,7 @@ export const TableReleases: FC<{showCurrent: boolean, limit?: number, page?: num
   }, {} as Record<string, {version: string, lts: string, eolDate: string, isLatest: boolean}>);
 
   const latestLts = currentReleases.filter((release) => release.lts !== "3").sort((a, b) => a.minor - b.minor)[0];
-  const latestAgile = currentReleases.filter((release) => release.lts === "3").sort((a, b) => a.minor - b.minor)[0];
+  const latestCurrent = currentReleases.filter((release) => release.lts === "3").sort((a, b) => a.minor - b.minor)[0];
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -117,7 +117,7 @@ export const TableReleases: FC<{showCurrent: boolean, limit?: number, page?: num
               >
 
                 <td className="px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
-                  <Link href={`changelogs?lts=true#v${release.minor}`}>
+                  <Link href={`changelogs?v=${release.minor}`}>
                     {release.minor}
                   </Link>
                 </td>

--- a/components/shared/dropdown.js
+++ b/components/shared/dropdown.js
@@ -1,4 +1,7 @@
-import { useState, useRef } from 'react';
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { ChevronDown } from "lucide-react";
 
 /**
  * Dropdown component that allows users to select an item from a list.
@@ -8,13 +11,25 @@ import { useState, useRef } from 'react';
  * @param {Array<string>} props.items - The list of items to display in the dropdown.
  * @param {string} props.label - The label to display when no item is selected.
  * @param {function} props.onSelect - The callback function to call when an item is selected.
+ * @param {boolean} props.includeAll - If true, start dropdown with 'All' option.
  *
  * @returns {JSX.Element} The rendered dropdown component.
  */
-export default function Dropdown({ items, label, onSelect }) {
+export default function Dropdown({ items, label, onSelect, includeAll=false }) {
     const [isOpen, setIsOpen] = useState(false);
     const [selectedItem, setSelectedItem] = useState(null);
     const dropdownRef = useRef(null);
+
+    useEffect(() => {
+        const handleClickOutside = (event) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+                setIsOpen(false);
+            }
+        };
+
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, []);
 
     const toggleDropdown = () => setIsOpen(!isOpen);
 
@@ -28,38 +43,32 @@ export default function Dropdown({ items, label, onSelect }) {
     };
 
     return (
-        <div className="relative z-10 inline-block text-left text-blue-700" ref={dropdownRef}>
+        <div className="relative" ref={dropdownRef}>
             <button
-                className="inline-flex min-h-10 w-full items-center justify-between rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium shadow-sm hover:bg-gray-50 focus:outline-none"
-                onClick={toggleDropdown}>
+                onClick={toggleDropdown}
+                className="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium 
+                    bg-background border border-input hover:bg-accent hover:text-accent-foreground
+                    transition-colors">
                 {selectedItem ? selectedItem : label}
-                <svg
-                    className="-mr-1 ml-2 size-5 text-gray-400"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor">
-                    <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                        d="M19 9l-7 7-7-7"
-                    />
-                </svg>
+                <ChevronDown className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
             </button>
-
+            
             {isOpen && (
-                <div className="absolute left-0 z-10 mt-2 w-full origin-top-right rounded-md border border-gray-200 bg-white shadow-lg">
-                    <ul className="py-1">
-                        {['All', ...items].map((item, index) => (
-                            <li
-                                key={index}
-                                className={`cursor-pointer px-4 py-2 text-sm hover:bg-gray-100 ${item === selectedItem ? 'bg-gray-100' : ''}`}
-                                onClick={() => handleSelect(item)}>
-                                {item}
-                            </li>
-                        ))}
-                    </ul>
+                <div className="absolute z-50 mt-2 w-48 rounded-md shadow-lg">
+                    <div className="rounded-md ring-1 ring-black ring-opacity-5 bg-background border border-input">
+                        <div className="py-1">
+                            {(includeAll ? ['All', ...items] : [...items]).map((item) => (
+                                <button
+                                    key={item}
+                                    onClick={() => handleSelect(item)}
+                                    className="block w-full text-left px-4 py-2 text-sm
+                                        hover:bg-accent hover:text-accent-foreground
+                                        transition-colors">
+                                    {item}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
                 </div>
             )}
         </div>

--- a/hooks/useChangelog.ts
+++ b/hooks/useChangelog.ts
@@ -9,9 +9,10 @@ interface ChangelogData {
     hasNextPage: boolean;
     hasPreviousPage: boolean;
   };
+  ltsMajors: any[];
 }
 
-export function useChangelog(currentPage: number = 1, isLts: boolean = false) {
+export function useChangelog(currentPage: number = 1, vLts: string = "false", singleVersion: string = "") {
   const [data, setData] = useState<ChangelogData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -24,7 +25,7 @@ export function useChangelog(currentPage: number = 1, isLts: boolean = false) {
     async function fetchChangelog() {
       try {
         setLoading(true);
-        const result = await getChangelog({ page, isLts });
+        const result = await getChangelog({ page, vLts, singleVersion });
         if (result) {
           setData(result);
         } else {
@@ -38,7 +39,7 @@ export function useChangelog(currentPage: number = 1, isLts: boolean = false) {
     }
 
     fetchChangelog();
-  }, [page, isLts]);
+  }, [page, vLts]);
 
   return { 
     data, 

--- a/services/docs/getChangelog/getChangelog.ts
+++ b/services/docs/getChangelog/getChangelog.ts
@@ -5,50 +5,92 @@ import { SIZE_PAGE } from './config';
 import { logRequest } from '@/util/logRequest'; 
 import { getGraphqlResults } from '@/services/gql';
 
-
-export const getChangelog = async ({ page = 1, isLts = false,limit = SIZE_PAGE, lts=false }) => {
-
-  const ltsQuery = isLts ? '+(Dotcmsbuilds.lts:1 Dotcmsbuilds.lts:2)' : '+Dotcmsbuilds.lts:3';
+export const getChangelog = async ({ page = 1, vLts = "false", singleVersion = "", limit = SIZE_PAGE }) => {
+  const assembleQuery = (buildQuery:string, ltsQuery:string, ltsMajVersion:string, singleVersion:string,
+                          limit:number, page:number, sortBy:string) => {
+    return `query ContentAPI {
+      DotcmsbuildsCollection(
+          query: "${buildQuery} ${ltsQuery} ${ltsMajVersion} ${singleVersion}"
+          limit: ${limit}
+          page: ${page}
+          sortBy: "${sortBy}"
+      ) {
+          title
+          minor
+          releaseNotes
+          releasedDate
+          dockerImage
+          showInChangeLog
+          released
+          lts
+          download
+          showInChangeLog
+          live
+          tags
+          eolDate
+      }
+      Pagination {
+          fieldName
+          totalPages
+          totalRecords
+          pageRecords
+          hasNextPage
+          hasPreviousPage
+          pageSize
+          page
+          offset
+      }
+    }`;
+  };
+  
+  //Basic type info for querying any changelogs at all
   const buildQuery =
-    '+contentType:Dotcmsbuilds +Dotcmsbuilds.released:true +Dotcmsbuilds.showInChangeLog:true +live:true';
+  '+contentType:Dotcmsbuilds +Dotcmsbuilds.released:true +Dotcmsbuilds.showInChangeLog:true +live:true';
 
+  //Build query components to grab one of each of the LTS major versions, for reference
+  const ltsQueryMaj = '+Dotcmsbuilds.lts:1';
+  const sortByEol = 'Dotcmsbuilds.eolDate desc';
+  const ltsMajorQuery = assembleQuery(buildQuery, ltsQueryMaj, "", "", limit, page, sortByEol);
+  const ltsMajorData =  await logRequest(async () => getGraphqlResults(ltsMajorQuery), 'getLTSMajorVersions');
 
-  const query = `query ContentAPI {
-    DotcmsbuildsCollection(
-        query: "${buildQuery} ${ltsQuery}"
-        limit: ${limit}
-        page: ${page}
-        sortBy: "Dotcmsbuilds.releasedDate desc"
-    ) {
-        title
-        minor
-        releaseNotes
-        releasedDate
-        dockerImage
-        showInChangeLog
-        released
-        lts
-        download
-        showInChangeLog
-        live
-
+  //if singleVersion is provided, check if it's an LTS patch version
+  let ltsPatchVersion = "";
+  if(singleVersion){
+    for(const item of ltsMajorData.DotcmsbuildsCollection){
+      for (const vTag of item.tags){
+        if(singleVersion.includes(vTag) && singleVersion === item.minor){
+          vLts = vTag;
+          ltsPatchVersion = vTag;
+          break;
+        }
+      }
+      if(ltsPatchVersion){
+        break;
+      }
     }
-    Pagination {
-        fieldName
-        totalPages
-        totalRecords
-        pageRecords
-        hasNextPage
-        hasPreviousPage
-        pageSize
-        page
-        offset
-    }
-}`;
+  }
+  console.log("singleVersion:", singleVersion);
+  console.log("ltsPatchVersion:", ltsPatchVersion);
 
-const data = await logRequest(async () => getGraphqlResults(query), 'getChangelog');
+  //Build query components to grab requested changelogs
+  const ltsQuery = (vLts && vLts !== "false") ? '+(Dotcmsbuilds.lts:1 Dotcmsbuilds.lts:2)' : '+Dotcmsbuilds.lts:3';
+  const sussOutLatestMajor = (majVersion:any, paramVersion:string) => {
+    if(/^\d/.test(paramVersion)){
+      return `+Dotcmsbuilds.tags:${paramVersion}`
+    } else if(paramVersion === "true"){
+      for (const vTag of majVersion.tags) {
+        if(/^\d/.test(vTag)) {
+          return `+Dotcmsbuilds.tags:${vTag}`;
+        }
+      }
+      return "";
+    } else return "";
+  };
+  const ltsMajVersion = sussOutLatestMajor(ltsMajorData.DotcmsbuildsCollection[0], vLts);
+  //console.log("sussed as:", ltsMajVersion);
+  const sortBy = 'Dotcmsbuilds.releasedDate desc';
+  const query = assembleQuery(buildQuery, ltsQuery, ltsMajVersion, (singleVersion && !ltsPatchVersion) ? `+Dotcmsbuilds.minor:${singleVersion}` : "", (ltsMajVersion ? 25 : limit), page, sortBy);
+  const data = await logRequest(async () => getGraphqlResults(query), 'getChangelog');
 
-return {changelogs: data.DotcmsbuildsCollection, pagination: data.Pagination[0]};
+  return {changelogs: data.DotcmsbuildsCollection, pagination: data.Pagination[0], ltsMajors: ltsMajorData.DotcmsbuildsCollection, ltsSingleton: ltsPatchVersion};
 };
-
-


### PR DESCRIPTION
The rare Changelog changelog:
- LTS picker interface changed from chips to dropdown
  - Cursor really made setting up dark mode trivial, huh!
- LTS picker works perfectly, selector labels will add (Latest)/(Past EOL) if appropriate 
- Added an individual-version param (`v=`)
  - On Current, it’ll return just that version
  - On LTS, it’ll return the entire major LTS version, then scroll to the indicated patch
  - This should also make batch-editing old/rotted links simple; if we see a link to `.../changelogs` that includes a `#`, we can just swap that octothorp (or maybe everything after the slug but before the fragment) for `?v=` — should cover most cases!
- Small miscellaneous changes to changelogs page `<main>` style classes to make sure indentation matched other docs

All Releases:
- With that new Changelog linking behavior, the All Releases table link issue was trivial to fix, with no special LTS vs Current logic needed.