### PR TITLE
Fixed param string on page 1 link

### DIFF
--- a/components/PaginationBar.js
+++ b/components/PaginationBar.js
@@ -31,7 +31,7 @@ export default function PaginationBar({ pagination, additionalQueryParams }) {
 
     const pages = Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i)
 
-    console.log(additionalQueryParams);
+    //console.log(additionalQueryParams);
     const finalAdditionalQueryParams = additionalQueryParams && additionalQueryParams.length > 0 ? additionalQueryParams : "";
 
     return (
@@ -49,7 +49,7 @@ export default function PaginationBar({ pagination, additionalQueryParams }) {
                 {startPage > 1 && (
                     <>
                         <PaginationItem>
-                            <PaginationLink href="?page=1&${finalAdditionalQueryParams}">1</PaginationLink>
+                            <PaginationLink href={`?page=1&${finalAdditionalQueryParams}`}>1</PaginationLink>
                         </PaginationItem>
                         {startPage > 2 && (
                             <PaginationItem>


### PR DESCRIPTION
Clicking the Page 1 link on the All Releases table would take you here:

![image](https://github.com/user-attachments/assets/20c42351-6f3a-416a-982b-5679f106ded2)

Turns out it was just a string that thought it was a template literal!