### PR TITLE
adding blog seo, github cache purge action

### DIFF
--- a/.github/workflows/flush-cdn-after-merge.yml
+++ b/.github/workflows/flush-cdn-after-merge.yml
@@ -1,0 +1,38 @@
+name: Flush CDN After Merge
+
+on:
+  push:
+    branches: [ main,testing ]
+
+  workflow_dispatch:
+    
+
+jobs:
+  flush-cdn-after-merge:
+    runs-on: ubuntu-latest
+    
+    steps:
+
+    - name: Flush CDN after merge
+      run: |
+        sleep 120 # Wait for the CDN to be updated
+        curl --request POST \
+            --url https://api.bunny.net/pullzone/${{ secrets.BUNNY_PULLZONE_ID }}/purgeCache \
+            --header 'AccessKey: ${{ secrets.BUNNY_ACCESS_KEY }}' \
+            --header 'content-type: application/json'
+        sleep 120 # Wait for the CDN to be updated
+        curl --request POST \
+            --url https://api.bunny.net/pullzone/${{ secrets.BUNNY_PULLZONE_ID }}/purgeCache \
+            --header 'AccessKey: ${{ secrets.BUNNY_ACCESS_KEY }}' \
+            --header 'content-type: application/json'
+
+
+
+
+
+# Purging the CDN curl command
+# curl --request POST \
+#     --url https://api.bunny.net/pullzone/${{ secrets.BUNNY_PULLZONE_ID }}/purgeCache \
+#     --header 'AccessKey: ${{ secrets.BUNNY_ACCESS_KEY }}' \
+#     --header 'content-type: application/json'
+#

--- a/app/blog/[slug]/page.js
+++ b/app/blog/[slug]/page.js
@@ -4,7 +4,7 @@ import Footer from "@/components/footer";
 import { notFound } from "next/navigation";
 import BlogDetailComponent from "@/components/blogs/blog-detail";
 import { ErrorPage } from "@/components/error";
-
+import { extractAssetId } from "@/util/utils";
 
 export async function generateMetadata({ params, searchParams }) {
     const finalParams = await params;
@@ -21,20 +21,26 @@ export async function generateMetadata({ params, searchParams }) {
         };
     }
 
-    const imageUrl = post.image?.fileAsset?.idPath 
-        ? `${post.host.hostname}/dA/${post.identifier}/70q/1000maxw/${post.inode}`
-        : `${post.host.hostname}/images/default-blog-image.jpg`;
+    let hostname = post.host?.hostname || 'https://dev.dotcms.com';
+    if(hostname === 'dotcms.com') {
+        hostname = 'https://www.dotcms.com';
+    }else if(hostname === 'dev.dotcms.dev') {
+        hostname = 'https://dev.dotcms.com';
+    }
+    const imageUrl = post.image?.fileAsset?.idPath  
+        ? `${hostname}/dA/${extractAssetId(post.image.fileAsset.idPath)}/70q/1000maxw/${post.inode}`
+        : `${hostname}/images/default-blog-image.jpg`;
 
     return {
         title: post.title,
         description: post.teaser || `Read ${post.title} on dotCMS Developer Blog`,
-        canonical: `${post.host.hostname}/blog/${post.urlTitle}`,
+        canonical: `${hostname}/blog/${post.urlTitle}`,
         
         // OpenGraph
         openGraph: {
             title: post.title,
             description: post.teaser,
-            url: `${post.host.hostname}/blog/${post.urlTitle}`,
+            url: `${hostname}/blog/${post.urlTitle}`,
             siteName: 'dotCMS Developer Blog',
             images: [{
                 url: imageUrl,

--- a/services/blog/getBlogDetail.js
+++ b/services/blog/getBlogDetail.js
@@ -29,6 +29,7 @@ export async function getBlogDetailQuery(urlTitle) {
             idPath
             name
             
+            
           }
         }
         categories {
@@ -46,6 +47,8 @@ export async function getBlogDetailQuery(urlTitle) {
         image {
             fileAsset{
             versionPath
+            idPath
+            name
             }
             description
         }   

--- a/util/utils.ts
+++ b/util/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+
+export function extractAssetId(uri: string) {
+    const match = uri.match(/\/dA\/([^/]+)/);
+    return match ? match[1] : null;
+}


### PR DESCRIPTION
This pull request includes various changes to improve the functionality and maintainability of the codebase. The most important changes are the addition of a new GitHub workflow to flush the CDN after merges, and updates to the blog page metadata generation to handle different hostnames and extract asset IDs.

### New GitHub Workflow:

* [`.github/workflows/flush-cdn-after-merge.yml`](diffhunk://#diff-ac20437e3489b85633a60ac4cce3993cd84168a587507568699d74af55155160R1-R38): Added a new workflow to flush the CDN cache after merges to the `main` and `testing` branches. This includes a job that waits for the CDN to update and then sends a POST request to purge the cache.

### Blog Page Metadata Generation:

* `app/blog/[slug]/page.js`: Updated the `generateMetadata` function to handle different hostnames (`dotcms.com`, `dev.dotcms.dev`) and extract asset IDs for image URLs using the new `extractAssetId` utility function. ([app/blog/[slug]/page.jsL7-R7](diffhunk://#diff-3da88423af16b56f5ab70782b40223d866016eb339b472f3b54812bfacb9e102L7-R7), [app/blog/[slug]/page.jsR24-R43](diffhunk://#diff-3da88423af16b56f5ab70782b40223d866016eb339b472f3b54812bfacb9e102R24-R43))

### Utility Function Addition:

* [`util/utils.ts`](diffhunk://#diff-6b1acb8dd9fb8a9030512638f8340b21f3057542ce7981816f72f0988ff616e9R7-R12): Added a new utility function `extractAssetId` to extract the asset ID from a given URI. This function is used in the blog page metadata generation.

### Blog Detail Query Updates:

* [`services/blog/getBlogDetail.js`](diffhunk://#diff-8bcc05f104b8c7801f69c05498cc7eb3e4abaa9b2ca9ba936895b7f1f659f59aR32): Updated the `getBlogDetailQuery` function to include `idPath` and `name` fields for `fileAsset` in the image object. [[1]](diffhunk://#diff-8bcc05f104b8c7801f69c05498cc7eb3e4abaa9b2ca9ba936895b7f1f659f59aR32) [[2]](diffhunk://#diff-8bcc05f104b8c7801f69c05498cc7eb3e4abaa9b2ca9ba936895b7f1f659f59aR50-R51)