### PR TITLE
TOC sidebar and scrolling fixes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,8 @@ import { ThemeProvider } from '@/components/header/theme-provider';
 import { Toaster } from '@/components/ui/toaster';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import { GoogleAnalytics } from '@next/third-parties/google'
+import { ScrollLock } from '@/components/ScrollLock';
+
 const inter = Inter({ 
   subsets: ['latin'],
   display: 'swap',
@@ -69,6 +71,7 @@ export default function RootLayout({
             enableSystem
             disableTransitionOnChange
           >
+            <ScrollLock />
             {children}
             <Toaster />
           </ThemeProvider>

--- a/components/ScrollLock.tsx
+++ b/components/ScrollLock.tsx
@@ -5,42 +5,8 @@ import { useEffect } from 'react';
 export function ScrollLock() {
   useEffect(() => {
     const initialScroll = window.scrollY;
-    console.log('ScrollLock initialized:', {
-      initialScroll,
-      timestamp: new Date().toISOString(),
-      documentHeight: document.documentElement.scrollHeight,
-      viewportHeight: window.innerHeight
-    });
-
+    
     const restore = () => {
-      const currentScroll = window.scrollY;
-      const delta = currentScroll - initialScroll;
-      
-      // Only look at elements near the scroll position
-      const relevantElements = Array.from(document.querySelectorAll('*'))
-        .filter(el => {
-          const rect = el.getBoundingClientRect();
-          const absoluteTop = rect.top + window.scrollY;
-          // Look at elements around the scroll position (±100px)
-          return Math.abs(absoluteTop - currentScroll) < 100;
-        })
-        .map(el => ({
-          element: el.tagName,
-          id: el.id,
-          className: el.className,
-          top: el.getBoundingClientRect().top + window.scrollY,
-          height: el.getBoundingClientRect().height
-        }))
-        .sort((a, b) => a.top - b.top); // Sort by position
-
-      console.log('Scroll prevented:', {
-        from: initialScroll,
-        attempted: currentScroll,
-        delta,
-        timestamp: new Date().toISOString(),
-        relevantElements
-      });
-      
       window.scrollTo(0, initialScroll);
     };
 

--- a/components/ScrollLock.tsx
+++ b/components/ScrollLock.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from 'react';
+
+export function ScrollLock() {
+  useEffect(() => {
+    const initialScroll = window.scrollY;
+    console.log('ScrollLock initialized:', {
+      initialScroll,
+      timestamp: new Date().toISOString(),
+      documentHeight: document.documentElement.scrollHeight,
+      viewportHeight: window.innerHeight
+    });
+
+    const restore = () => {
+      const currentScroll = window.scrollY;
+      const delta = currentScroll - initialScroll;
+      
+      // Only look at elements near the scroll position
+      const relevantElements = Array.from(document.querySelectorAll('*'))
+        .filter(el => {
+          const rect = el.getBoundingClientRect();
+          const absoluteTop = rect.top + window.scrollY;
+          // Look at elements around the scroll position (±100px)
+          return Math.abs(absoluteTop - currentScroll) < 100;
+        })
+        .map(el => ({
+          element: el.tagName,
+          id: el.id,
+          className: el.className,
+          top: el.getBoundingClientRect().top + window.scrollY,
+          height: el.getBoundingClientRect().height
+        }))
+        .sort((a, b) => a.top - b.top); // Sort by position
+
+      console.log('Scroll prevented:', {
+        from: initialScroll,
+        attempted: currentScroll,
+        delta,
+        timestamp: new Date().toISOString(),
+        relevantElements
+      });
+      
+      window.scrollTo(0, initialScroll);
+    };
+
+    window.addEventListener('scroll', restore, { once: true });
+    return () => window.removeEventListener('scroll', restore);
+  }, []);
+  
+  return null;
+}

--- a/components/changelogs/ChangeLogList.js
+++ b/components/changelogs/ChangeLogList.js
@@ -20,6 +20,7 @@ export default function ChangeLogContainer({ sideNav, slug }) {
   const [singleVersion, setSingleVersion] = useState(searchParams.get("v"));
 
   let isLts = paramLts && paramLts !== "false";
+  let vLts = "";
   let currentPage = Number(searchParams.get("page")) || 1;
   if (currentPage < 1) {
     currentPage = 1;
@@ -148,7 +149,7 @@ export default function ChangeLogContainer({ sideNav, slug }) {
                     }
                   }
                 }
-                let vLts = paramLts === "true" ? ltsMajorVersions[0] : paramLts; // set the effective LTS version based on URL param
+                vLts = paramLts === "true" ? ltsMajorVersions[0] : paramLts; // set the effective LTS version based on URL param
                 if(isLts && !vLts){
                   vLts = data.ltsSingleton;
                 }
@@ -200,6 +201,8 @@ export default function ChangeLogContainer({ sideNav, slug }) {
             <OnThisPage
               selectors={"main h1, main h2"}
               showOnThisPage={false}
+              showTitle={false}
+              titleOverride={vLts ? `${vLts} LTS` : "Current"}
               className="border-2 border-red-500"
             />
 

--- a/components/changelogs/ChangeLogList.js
+++ b/components/changelogs/ChangeLogList.js
@@ -198,7 +198,7 @@ export default function ChangeLogContainer({ sideNav, slug }) {
             )}
 
             <OnThisPage
-              selectors={"main h2"}
+              selectors={"main h1, main h2"}
               showOnThisPage={false}
               className="border-2 border-red-500"
             />

--- a/components/navigation/OnThisPage.js
+++ b/components/navigation/OnThisPage.js
@@ -4,9 +4,9 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { smoothScroll } from '@/util/smoothScroll';
 
-export const OnThisPage = ({selectors, showOnThisPage = true}) => {
+export const OnThisPage = ({selectors = 'main h1, main h2, main h3, main h4, main h2, main h3, main h4, .dot-block-editor h1, .dot-block-editor h2, .dot-block-editor h3, .dot-block-editor h4', showOnThisPage = true}) => {
   const [items, setItems] = useState([]);
-  const [mySelectors, setMySelectors] = useState('main h2, main h3, main h4, main h2, main h3, main h4, .dot-block-editor h1, .dot-block-editor h2, .dot-block-editor h3, .dot-block-editor h4');
+  const [mySelectors, setMySelectors] = useState(selectors);
 
 
   useEffect(() => {
@@ -56,7 +56,14 @@ export const OnThisPage = ({selectors, showOnThisPage = true}) => {
   }
 
   return (
-    <div className="sticky top-8 pb-12">
+    <div className="sticky top-8 pb-12 
+                overflow-y-auto p-4 px-2
+                [&::-webkit-scrollbar]:w-1.5
+                [&::-webkit-scrollbar-track]:bg-transparent
+                [&::-webkit-scrollbar-thumb]:bg-muted-foreground/10
+                [&::-webkit-scrollbar-thumb]:rounded-full
+                hover:[&::-webkit-scrollbar-thumb]:bg-muted-foreground/20
+                h-[calc(100vh-4rem)]" >
       {showOnThisPage && (
         <h3 className="mb-4 text-sm font-semibold">On This Page</h3>
       )}
@@ -66,9 +73,9 @@ export const OnThisPage = ({selectors, showOnThisPage = true}) => {
             <li 
               key={item.id}
               className={`
-                ${item.level === 1 ? 'ml-0 font-semibold' : ''}
-                ${item.level === 2 ? 'ml-0 font-semibold' : ''}
-                ${(item.level === 3 || item.level === 4) ? 'ml-3 font-normal text-muted-foreground' : ''}
+                ${item.level === 1 ? 'ml-0 font-bold' : ''}
+                ${item.level === 2 ? 'ml-2 font-semibold' : ''}
+                ${(item.level === 3 || item.level === 4) ? 'ml-4 font-normal text-muted-foreground' : ''}
               `}
             >
               <Link 

--- a/components/navigation/OnThisPage.js
+++ b/components/navigation/OnThisPage.js
@@ -4,7 +4,11 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { smoothScroll } from '@/util/smoothScroll';
 
-export const OnThisPage = ({selectors = 'main h1, main h2, main h3, main h4, main h2, main h3, main h4, .dot-block-editor h1, .dot-block-editor h2, .dot-block-editor h3, .dot-block-editor h4', showOnThisPage = true}) => {
+export const OnThisPage = ({
+  selectors = 'main h1, main h2, main h3, main h4, main h2, main h3, main h4, .dot-block-editor h1, .dot-block-editor h2, .dot-block-editor h3, .dot-block-editor h4', 
+  showOnThisPage = true,
+  titleOverride = undefined
+}) => {
   const [items, setItems] = useState([]);
   const [mySelectors, setMySelectors] = useState(selectors);
 
@@ -84,7 +88,7 @@ export const OnThisPage = ({selectors = 'main h1, main h2, main h3, main h4, mai
                 className="hover:text-foreground transition-colors block"
                 onClick={smoothScroll}
               >
-                {item.title}
+                {item.level === 1 ? (titleOverride || item.title) : item.title}
               </Link>
             </li>
           ))}

--- a/components/navigation/SubNavTree.tsx
+++ b/components/navigation/SubNavTree.tsx
@@ -20,16 +20,6 @@ type SubNavTreeProps = {
 
 const SubNavTree = React.memo(({ items=[], currentPath, level = 0, openSections, setOpenSections }: SubNavTreeProps) => {
   const relevantPath = currentPath.replace(/^\/docs\/latest\//, '');
-  const currentItemRef = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    if (currentItemRef.current) {
-      currentItemRef.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center'
-      });
-    }
-  }, [relevantPath]);
 
   const toggleSection = useCallback((urlTitle: string) => {
     setOpenSections((prev: string[]) => {
@@ -72,7 +62,6 @@ const SubNavTree = React.memo(({ items=[], currentPath, level = 0, openSections,
     if (hasChildren) {
       return (
         <Collapsible
-          ref={isCurrentPage ? currentItemRef : undefined}
           open={openSections.includes(item.urlTitle)}
           onOpenChange={() => toggleSection(item.urlTitle)}
         >

--- a/components/navigation/SubNavTree.tsx
+++ b/components/navigation/SubNavTree.tsx
@@ -20,6 +20,16 @@ type SubNavTreeProps = {
 
 const SubNavTree = React.memo(({ items=[], currentPath, level = 0, openSections, setOpenSections }: SubNavTreeProps) => {
   const relevantPath = currentPath.replace(/^\/docs\/latest\//, '');
+  const currentItemRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (currentItemRef.current) {
+      currentItemRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center'
+      });
+    }
+  }, [relevantPath]);
 
   const toggleSection = useCallback((urlTitle: string) => {
     setOpenSections((prev: string[]) => {
@@ -62,6 +72,7 @@ const SubNavTree = React.memo(({ items=[], currentPath, level = 0, openSections,
     if (hasChildren) {
       return (
         <Collapsible
+          ref={isCurrentPage ? currentItemRef : undefined}
           open={openSections.includes(item.urlTitle)}
           onOpenChange={() => toggleSection(item.urlTitle)}
         >

--- a/components/playgrounds/RestApiPlayground/CopyPlaygroundButton/CopyPlaygroundButton.tsx
+++ b/components/playgrounds/RestApiPlayground/CopyPlaygroundButton/CopyPlaygroundButton.tsx
@@ -43,5 +43,3 @@ const CopyPlaygroundButton: FC<TCopyPlaygroundButton> = ({ text, disabled }) => 
 };
 
 export default CopyPlaygroundButton;
-
-/**/

--- a/util/smoothScroll.ts
+++ b/util/smoothScroll.ts
@@ -1,16 +1,17 @@
 export function smoothScroll(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
     e.preventDefault();
+    e.stopPropagation();
     const href = e.currentTarget.getAttribute('href');
-    if (href && href.startsWith('#')) {
+    if (href?.startsWith('#')) {
       const targetId = href.substring(1);
       const elem = document.getElementById(targetId);
       if (elem) {
-        const headerOffset = 80; // Adjust this value based on your header height
-        const elementPosition = elem.getBoundingClientRect().top;
-        const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+        const headerOffset = 80;
+        // Get absolute position relative to document
+        const elementTop = elem.getBoundingClientRect().top + window.scrollY;
 
         window.scrollTo({
-          top: offsetPosition,
+          top: elementTop - headerOffset,
           behavior: 'smooth'
         });
         


### PR DESCRIPTION
## Right Sidebar

- TOC now actually uses selector args passed by different components, rather than just overriding everything with the same hardcoded panoply
- now also includes the H1, in case someone might want to jump to the top of the page
  - indents adjusted accordingly
  - added some special logic for the changelog title
- also now scrolls when when it's long enough to overflow
  - matches scrollbar styling of the right-hand nav

## Scroll Behavior

- Section headings no longer scroll up until they're hidden behind the page header
- Spent forever trying to debug what, exactly, during hydration was causing it to scroll 32 pixels farther down on every page refresh
- Finally gave up on that fool's errand and went the pragmatic route:
  - Added a ScrollLock component that fires on layout load
  - Toned up the smoothScroll function with some minor refactoring (such as moving from the deprecated `pageYOffset` to the modern `scrollY` property)
  - Added an extra `stopPropagation()` call to make sure this function is the only thing handling the behavior.

## Left Sidebar

~~- When a page is freshly loaded, it will helpfully start you off autoscrolling you to exactly where you are in the nav, rather than sticking you up at the top every time.~~

No change. I had added the struck-out thing above, but then removed the change in a subsequent commit. I had misunderstood the scroll behavior; when I had scrolled the nav up to the top and it saved the position, I interpreted it on later refreshes as "just resetting its position to the top — wouldn't it be better if it jumps right to the page you have open?" So, disregard!