### PR TITLE
LTS redirect to changelog

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,7 +25,7 @@ const nextConfig = {
           {
             source: '/docs/long-term-supported-releases',
             destination: '/docs/changelogs?lts=true',
-            permanent: false,
+            permanent: true,
           },
         ]
       },

--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,11 @@ const nextConfig = {
             destination: '/blog',
             permanent: true,
           },
+          {
+            source: '/docs/long-term-supported-releases',
+            destination: '/docs/changelogs?lts=true',
+            permanent: false,
+          },
         ]
       },
     images: {


### PR DESCRIPTION
I can't seem to get Vanity URLs to work on headless. If this is because I'm handling them wrong somehow; we can close this PR. Or if Vanity URLs are "traditional only," then this solves it.