### PR TITLE
Added check to prevent <div> in <p>

### DIFF
--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -90,9 +90,21 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
         </a>
       </h6>
     ),
-    p: ({ children }) => (
-      <p className="text-base leading-7 text-foreground mb-6">{children}</p>
-    ),
+    p: ({ children }) => {
+      // Check if children contains any div-producing components
+      const hasDiv = React.Children.toArray(children).some((child: any) => {
+        return React.isValidElement(child) && 
+          (child.type === Info || child.type === Warn || child.type === Include);
+      });
+
+      // If there's a div-producing component, render children directly without p wrapper
+      if (hasDiv) {
+        return <>{children}</>;
+      }
+
+      // Otherwise, wrap in p tag as before
+      return <p className="text-base leading-7 text-foreground mb-6">{children}</p>;
+    },
     ul: ({ children }) => <ul className="list-disc pl-6 mb-6">{children}</ul>,
     ol: ({ children }) => <ol className="list-decimal list-inside mb-4">{children}</ol>,
     li: ({ children }) => (


### PR DESCRIPTION
NextJS flags it as an error when a div is a descendent of a p.

![image](https://github.com/user-attachments/assets/b8545ccc-22ac-41d9-b78f-009132ae8062)

This means that all of our cool `<info>` boxes etc will cause issues. This fix just adds a check to the markdown output to check if a div might be downstream before printing a paragraph.

Before:

![image](https://github.com/user-attachments/assets/957af732-712f-40ee-88d9-8e34f3d07730)

After:

![image](https://github.com/user-attachments/assets/38cb379b-b54b-4273-8b3a-5bfe408f02dc)
