### PR TITLE
just some param fixes to even out CL/all-releases

### DIFF
--- a/components/PaginationBar.js
+++ b/components/PaginationBar.js
@@ -39,7 +39,7 @@ export default function PaginationBar({ pagination, additionalQueryParams }) {
             <PaginationContent>
                 <PaginationItem>
                     <PaginationPrevious
-                        href={`?page=${currentPage - 1}&${finalAdditionalQueryParams}`}
+                        href={`?page=${currentPage - 1}${finalAdditionalQueryParams}`}
                         aria-disabled={!hasPreviousPage}
                         className={!hasPreviousPage ? 'pointer-events-none opacity-50' : ''}
                     />
@@ -48,7 +48,7 @@ export default function PaginationBar({ pagination, additionalQueryParams }) {
                 {startPage > 1 && (
                     <>
                         <PaginationItem>
-                            <PaginationLink href={`?page=1&${finalAdditionalQueryParams}`}>1</PaginationLink>
+                            <PaginationLink href={`?page=1${finalAdditionalQueryParams}`}>1</PaginationLink>
                         </PaginationItem>
                         {startPage > 2 && (
                             <PaginationItem>
@@ -61,7 +61,7 @@ export default function PaginationBar({ pagination, additionalQueryParams }) {
                 {pages.map((page) => (
                     <PaginationItem key={page}>
                         <PaginationLink
-                            href={`?page=${page}&${finalAdditionalQueryParams}`}
+                            href={`?page=${page}${finalAdditionalQueryParams}`}
                             isActive={page === currentPage}
                         >
                             {page}
@@ -77,7 +77,7 @@ export default function PaginationBar({ pagination, additionalQueryParams }) {
                             </PaginationItem>
                         )}
                         <PaginationItem>
-                            <PaginationLink href={`?page=${totalPages}&${finalAdditionalQueryParams}`}>
+                            <PaginationLink href={`?page=${totalPages}${finalAdditionalQueryParams}`}>
                                 {totalPages}
                             </PaginationLink>
                         </PaginationItem>
@@ -86,7 +86,7 @@ export default function PaginationBar({ pagination, additionalQueryParams }) {
 
                 <PaginationItem>
                     <PaginationNext
-                        href={`?page=${currentPage + 1}&${finalAdditionalQueryParams}`}
+                        href={`?page=${currentPage + 1}${finalAdditionalQueryParams}`}
                         aria-disabled={!hasNextPage}
                         className={!hasNextPage ? 'pointer-events-none opacity-50' : ''}
                     />

--- a/components/changelogs/ChangeLogList.js
+++ b/components/changelogs/ChangeLogList.js
@@ -182,7 +182,7 @@ export default function ChangeLogContainer({ sideNav, slug }) {
         ))}
 
         <div className="mt-8 mb-12">
-            <PaginationBar pagination={data.pagination} currentPage={data.pagination.page} additionalQueryParams={`lts=${isLts}`} />
+            <PaginationBar pagination={data.pagination} currentPage={data.pagination.page} additionalQueryParams={isLts ? `&lts=${isLts}` : ""} />
         </div>
       </main>
       <div className="w-64 shrink-0 hidden xl:block">

--- a/components/releases/TableReleases/TableReleases.tsx
+++ b/components/releases/TableReleases/TableReleases.tsx
@@ -231,7 +231,7 @@ export const TableReleases: FC<{
         </table>
         {!showCurrent && (
           <div className="m-6">
-            <PaginationBar pagination={pagination} additionalQueryParams={`filter=${filter}&version=${version}`} />
+            <PaginationBar pagination={pagination} additionalQueryParams={`&filter=${filter}&version=${version}`} />
           </div>
         )}
       </div>


### PR DESCRIPTION
This prevents the no-longer-applicable `&lts=null` case in the changelog, as well as any chance of a dangling `&` at the end, without upsetting the all-releases table pagination.