### PR TITLE
fixes positioning for Newer/Older links on TOC

### DIFF
--- a/components/changelogs/ChangeLogList.js
+++ b/components/changelogs/ChangeLogList.js
@@ -187,7 +187,14 @@ export default function ChangeLogContainer({ sideNav, slug }) {
       </main>
       <div className="w-64 shrink-0 hidden xl:block">
         <div className="sticky top-16 pt-8 pl-8">
-          <div className="text-muted-foreground">
+          <div className="text-muted-foreground
+                overflow-y-auto p-4 px-2
+                [&::-webkit-scrollbar]:w-1.5
+                [&::-webkit-scrollbar-track]:bg-transparent
+                [&::-webkit-scrollbar-thumb]:bg-muted-foreground/10
+                [&::-webkit-scrollbar-thumb]:rounded-full
+                hover:[&::-webkit-scrollbar-thumb]:bg-muted-foreground/20
+                h-[calc(100vh-4rem)]">
             {hasPrevPage && (
               <a
                 title="Newer Releases"

--- a/components/documentation/Documentation.js
+++ b/components/documentation/Documentation.js
@@ -66,7 +66,14 @@ const Documentation = ({ contentlet, sideNav, slug }) => {
 
         {/* Right Sidebar - Hide on smaller screens */}
         <div className="w-64 shrink-0 hidden xl:block">
-          <div className="sticky top-16 pt-8 pl-8">
+          <div className="sticky top-16 pt-8 pl-8
+                overflow-y-auto p-4 px-2
+                [&::-webkit-scrollbar]:w-1.5
+                [&::-webkit-scrollbar-track]:bg-transparent
+                [&::-webkit-scrollbar-thumb]:bg-muted-foreground/10
+                [&::-webkit-scrollbar-thumb]:rounded-full
+                hover:[&::-webkit-scrollbar-thumb]:bg-muted-foreground/20
+                h-[calc(100vh-4rem)]">
             <OnThisPage />
           </div>
         </div>

--- a/components/navigation/OnThisPage.js
+++ b/components/navigation/OnThisPage.js
@@ -60,14 +60,7 @@ export const OnThisPage = ({
   }
 
   return (
-    <div className="sticky top-8 pb-12 
-                overflow-y-auto p-4 px-2
-                [&::-webkit-scrollbar]:w-1.5
-                [&::-webkit-scrollbar-track]:bg-transparent
-                [&::-webkit-scrollbar-thumb]:bg-muted-foreground/10
-                [&::-webkit-scrollbar-thumb]:rounded-full
-                hover:[&::-webkit-scrollbar-thumb]:bg-muted-foreground/20
-                h-[calc(100vh-4rem)]" >
+    <div className="sticky top-8 mb-12" >
       {showOnThisPage && (
         <h3 className="mb-4 text-sm font-semibold">On This Page</h3>
       )}


### PR DESCRIPTION
Moved the scrollbar styling on the TOC off of the OnThisPage component and onto its parent element, to avoid squishing the Older button all the way down into the unclickable depths of hell.