### PR TITLE
adds two more potential layers of depth to left nav

### DIFF
--- a/services/docs/getSideNav.ts
+++ b/services/docs/getSideNav.ts
@@ -3,7 +3,7 @@ import { logRequest } from '@/util/logRequest';
 const GRAPHQL_ENPOINT = `/api/v1/graphql`
 
 
-const cacheKey = "coreNavLeftCacheKey";
+const cacheKey = "coreNavLeftCacheKey_L6";
 export const getSideNav = async () => {
 
     const cachedValue = dotCache.get(cacheKey);
@@ -23,6 +23,10 @@ export const getSideNav = async () => {
                 urlTitle
                 modDate
                 dotcmsdocumentationchildren {
+                    title
+                    urlTitle
+                    modDate
+                    dotcmsdocumentationchildren {
                         title
                         urlTitle
                         modDate
@@ -34,7 +38,13 @@ export const getSideNav = async () => {
                                 title
                                 urlTitle
                                 modDate
+                                dotcmsdocumentationchildren {
+                                    title
+                                    urlTitle
+                                    modDate
+                                }
                             }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Adding two more levels of left-nav depth snags all the missing child items that would surface on searches but not on the nav itself.

Confirmed max depth via Velocity script; run the following in Velocity Playground:

```
## Initialize!
#set($toc = $dotcontent.find("211e0406-1c2e-4975-9027-3480c2088464"))
#set($L1 = [])
#set($L2 = [])
#set($L3 = [])
#set($L4 = [])
#set($L5 = [])
#set($L6 = [])
#set($L7 = [])
#set($L8 = [])
#set($L9 = [])
#set($L10 = [])
## GATHER ALL DATA ###############################
## L1
#foreach($section in $toc.dotcmsdocumentationchildren)
#set($dummy = $!L1.add($section))
#end
## L2
#foreach($item in $L1)
#foreach($section in $item.dotcmsdocumentationchildren)
#set($dummy = $!L2.add($section))
#end
#end
## L3
#foreach($item in $L2)
#foreach($section in $item.dotcmsdocumentationchildren)
#set($dummy = $!L3.add($section))
#end
#end
## L4
#foreach($item in $L3)
#foreach($section in $item.dotcmsdocumentationchildren)
#set($dummy = $!L4.add($section))
#end
#end
## L5
#foreach($item in $L4)
#foreach($section in $item.dotcmsdocumentationchildren)
#set($dummy = $!L5.add($section))
#end
#end
## L6
#foreach($item in $L5)
#foreach($section in $item.dotcmsdocumentationchildren)
#set($dummy = $!L6.add($section))
#end
#end
## L7
#foreach($item in $L6)
#foreach($section in $item.dotcmsdocumentationchildren)
#set($dummy = $!L7.add($section))
#end
#end
## L8
#foreach($item in $L7)
#foreach($section in $item.dotcmsdocumentationchildren)
#set($dummy = $!L8.add($section))
#end
#end
## L9
#foreach($item in $L8)
#foreach($section in $item.dotcmsdocumentationchildren)
#set($dummy = $!L9.add($section))
#end
#end
## L10
#foreach($item in $L9)
#foreach($section in $item.dotcmsdocumentationchildren)
#set($dummy = $!L10.add($section))
#end
#end
##
## SHOW ALL DATA #########################
##
L1
#foreach($item in $L1)
$item.title    -    $item.urlTitle
#end


L2
#foreach($item in $L2)
$item.title    -    $item.urlTitle
#end


L3
#foreach($item in $L3)
$item.title    -    $item.urlTitle
#end


L4
#foreach($item in $L4)
$item.title    -    $item.urlTitle
#end


L5
#foreach($item in $L5)
$item.title    -    $item.urlTitle
#end


L6
#foreach($item in $L6)
$item.title    -    $item.urlTitle
#end


L7
#foreach($item in $L7)
$item.title    -    $item.urlTitle
#end


L8
#foreach($item in $L8)
$item.title    -    $item.urlTitle
#end


L9
#foreach($item in $L9)
$item.title    -    $item.urlTitle
#end


L10
#foreach($item in $L10)
$item.title    -    $item.urlTitle
#end
```