### PR TITLE
Replacing Discord link with Discourse

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { Separator } from "@/components/ui/separator"
 import { Github, Twitter, Linkedin } from "lucide-react"
 import { Button } from "@/components/ui/button"
-
+import DiscourseLink from "@/components/header/DiscourseLink"
 export default function Footer() {
   return (
     <footer className="mt-auto border-t">
@@ -31,6 +31,12 @@ export default function Footer() {
             <Link href="https://linkedin.com/company/dotcms" target="_blank" rel="noopener noreferrer">
               <Linkedin className="h-5 w-5" />
               <span className="sr-only">LinkedIn</span>
+            </Link>
+          </Button>
+          <Button variant="ghost" size="icon" asChild className="hover:bg-transparent">
+            <Link href="https://community.dotcms.com" target="_blank" rel="noopener noreferrer">
+              <DiscourseLink position="footer" />
+              <span className="sr-only">Discourse</span>
             </Link>
           </Button>
         </div>

--- a/components/header/DiscourseLink.tsx
+++ b/components/header/DiscourseLink.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+
+export default function DiscourseLink({position = 'header'}: {readonly position?: 'header' | 'footer'}) {
+  // Replaced #231f20 with currentColor in SVG to make it theme aware
+  return (
+    <Link href="https://community.dotcms.com" target="_blank" rel="noreferrer" className="pl-[0.4em] md:p-2 text-current">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -1 106 106" height={position === 'header' ? "24" : "20"} width={position === 'header' ? "24" : "20"}>
+        <path fill="currentColor" d="M51.87 0C23.71 0 0 22.83 0 51v52.81l51.86-.05c28.16 0 51-23.71 51-51.87S80 0 51.87 0Z"/>
+        <path fill="#fff9ae" d="M52.37 19.74a31.62 31.62 0 0 0-27.79 46.67l-5.72 18.4 20.54-4.64a31.61 31.61 0 1 0 13-60.43Z"/>
+        <path fill="#00aeef" d="M77.45 32.12a31.6 31.6 0 0 1-38.05 48l-20.54 4.7 20.91-2.47a31.6 31.6 0 0 0 37.68-50.23Z"/>
+        <path fill="#00a94f" d="M71.63 26.29A31.6 31.6 0 0 1 38.8 78l-19.94 6.82 20.54-4.65a31.6 31.6 0 0 0 32.23-53.88Z"/>
+        <path fill="#f15d22" d="M26.47 67.11a31.61 31.61 0 0 1 51-35 31.61 31.61 0 0 0-52.89 34.3l-5.72 18.4Z"/>
+        <path fill="#e31b23" d="M24.58 66.41a31.61 31.61 0 0 1 47.05-40.12 31.61 31.61 0 0 0-49 39.63l-3.76 18.9Z"/>
+        <title>dotCMS Discourse Community</title>
+      </svg>
+      <span className="sr-only">dotCMS Discourse Community</span>
+    </Link>
+  );
+};

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -23,7 +23,7 @@ import Link from "next/link";
 import * as React from "react";
 import { cn } from "@/util/utils";
 import { useState, useEffect } from "react"
-import DiscordLink from "./DiscordLink";
+import DiscourseLink from "./DiscourseLink";
 import GithubLink from "./GithubLink";
 import Logo from "./Logo/Logo";
 import { SearchModal } from "../chat/SearchModal";
@@ -256,7 +256,7 @@ export default function Header({ sideNavItems, currentPath }: HeaderProps) {
 
             <div className="hidden lg:flex items-center space-x-2">
               <GithubLink />
-              <DiscordLink />
+              <DiscourseLink />
               <ThemeToggle />
             </div>
 
@@ -304,7 +304,7 @@ export default function Header({ sideNavItems, currentPath }: HeaderProps) {
                 
                 <div className="flex items-center gap-2 px-2">
                   <GithubLink />
-                  <DiscordLink />
+                  <DiscourseLink />
                   <ThemeToggle />
                 </div>
               </div>


### PR DESCRIPTION
Swapping out the Discord gem for the new Discourse community board, per Marketing's request.

I resized this SVG: https://upload.wikimedia.org/wikipedia/commons/1/17/Discourse_icon.svg

And then replaced the dark fill with `currentColor` to be modestly theme-aware.

Header:
![image](https://github.com/user-attachments/assets/778a4c6b-7975-4d93-86ce-03d30b370a97)
![image](https://github.com/user-attachments/assets/327e1ac0-d4b5-47f6-a1a4-0d00b627f687)

Footer:
![image](https://github.com/user-attachments/assets/68b88a99-80c5-4710-a5eb-e02598771817)
![image](https://github.com/user-attachments/assets/6ac16039-0620-439c-8e53-651c6253fc09)

I kinda want to go full-monochrome in dark mode, but that requires significantly more finesse, since SVGs are not the most cooperative critters.