### PR TITLE
make discourse icon black white

### DIFF
--- a/components/header/DiscourseLink.tsx
+++ b/components/header/DiscourseLink.tsx
@@ -2,18 +2,10 @@ import Link from 'next/link';
 
 
 export default function DiscourseLink({position = 'header'}: {readonly position?: 'header' | 'footer'}) {
-  // Replaced #231f20 with currentColor in SVG to make it theme aware
+
   return (
     <Link href="https://community.dotcms.com" target="_blank" rel="noreferrer" className="pl-[0.4em] md:p-2 text-current">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -1 106 106" height={position === 'header' ? "24" : "20"} width={position === 'header' ? "24" : "20"}>
-        <path fill="currentColor" d="M51.87 0C23.71 0 0 22.83 0 51v52.81l51.86-.05c28.16 0 51-23.71 51-51.87S80 0 51.87 0Z"/>
-        <path fill="#fff9ae" d="M52.37 19.74a31.62 31.62 0 0 0-27.79 46.67l-5.72 18.4 20.54-4.64a31.61 31.61 0 1 0 13-60.43Z"/>
-        <path fill="#00aeef" d="M77.45 32.12a31.6 31.6 0 0 1-38.05 48l-20.54 4.7 20.91-2.47a31.6 31.6 0 0 0 37.68-50.23Z"/>
-        <path fill="#00a94f" d="M71.63 26.29A31.6 31.6 0 0 1 38.8 78l-19.94 6.82 20.54-4.65a31.6 31.6 0 0 0 32.23-53.88Z"/>
-        <path fill="#f15d22" d="M26.47 67.11a31.61 31.61 0 0 1 51-35 31.61 31.61 0 0 0-52.89 34.3l-5.72 18.4Z"/>
-        <path fill="#e31b23" d="M24.58 66.41a31.61 31.61 0 0 1 47.05-40.12 31.61 31.61 0 0 0-49 39.63l-3.76 18.9Z"/>
-        <title>dotCMS Discourse Community</title>
-      </svg>
+      <svg fill="currentColor" height={position === 'header' ? "24" : "20"} width={position === 'header' ? "24" : "20"} viewBox="0 0 24 24" role="img" xmlns="http://www.w3.org/2000/svg"><path d="M12.103 0C18.666 0 24 5.485 24 11.997c0 6.51-5.33 11.99-11.9 11.99L0 24V11.79C0 5.28 5.532 0 12.103 0zm.116 4.563a7.395 7.395 0 0 0-6.337 3.57 7.247 7.247 0 0 0-.148 7.22L4.4 19.61l4.794-1.074a7.424 7.424 0 0 0 8.136-1.39 7.256 7.256 0 0 0 1.737-7.997 7.375 7.375 0 0 0-6.84-4.585h-.008z"/></svg>
       <span className="sr-only">dotCMS Discourse Community</span>
     </Link>
   );

--- a/components/header/DiscourseLink.tsx
+++ b/components/header/DiscourseLink.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 export default function DiscourseLink({position = 'header'}: {readonly position?: 'header' | 'footer'}) {
 
   return (
-    <Link href="https://community.dotcms.com" target="_blank" rel="noreferrer" className="pl-[0.4em] md:p-2 text-current">
+    <Link href="https://community.dotcms.com" title="dotCMS Discourse Community" aria-label="dotCMS Discourse Community" prefetch={false} target="_blank" rel="noreferrer" className="pl-[0.4em] md:p-2 text-current">
       <svg fill="currentColor" height={position === 'header' ? "24" : "20"} width={position === 'header' ? "24" : "20"} viewBox="0 0 24 24" role="img" xmlns="http://www.w3.org/2000/svg"><path d="M12.103 0C18.666 0 24 5.485 24 11.997c0 6.51-5.33 11.99-11.9 11.99L0 24V11.79C0 5.28 5.532 0 12.103 0zm.116 4.563a7.395 7.395 0 0 0-6.337 3.57 7.247 7.247 0 0 0-.148 7.22L4.4 19.61l4.794-1.074a7.424 7.424 0 0 0 8.136-1.39 7.256 7.256 0 0 0 1.737-7.997 7.375 7.375 0 0 0-6.84-4.585h-.008z"/></svg>
       <span className="sr-only">dotCMS Discourse Community</span>
     </Link>


### PR DESCRIPTION
- **making discourse black and white like our other icons**

![image](https://github.com/user-attachments/assets/aabc95d0-9280-4282-b707-5c8ca7cfce07)

