### PR TITLE
added hard-coded LMS card to the learning page

### DIFF
--- a/components/content-types/feature-card.tsx
+++ b/components/content-types/feature-card.tsx
@@ -34,7 +34,7 @@ export default function FeatureCard({
 }: FeatureCardProps) {
 
     const imageUrl = imageIdentifier && (imageIdentifier.startsWith('http') || imageIdentifier.startsWith('/dA/')) ? imageIdentifier : `${Config.CDNHost}/dA/${imageIdentifier}/`;
-    const myHref = count < 0 ? "#" : href;
+    const myHref = count === 0 ? "#" : href;
 
     return (
         <div className="space-y-4">
@@ -45,9 +45,13 @@ export default function FeatureCard({
                             <Icon className={`h-6 w-6 transition-colors group-hover:text-${color}`} />
                             <div className="flex items-center gap-2">
                                 <h3 className={`text-xl font-semibold transition-colors group-hover:text-${color}`}>{title}</h3>
-                                {count > 0 && (
+                                {count > 0 ? (
                                     <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
                                         {count}
+                                    </span>
+                                ) : (
+                                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
+                                        {'+'}
                                     </span>
                                 )}
                             </div>

--- a/components/content-types/feature-card.tsx
+++ b/components/content-types/feature-card.tsx
@@ -45,13 +45,9 @@ export default function FeatureCard({
                             <Icon className={`h-6 w-6 transition-colors group-hover:text-${color}`} />
                             <div className="flex items-center gap-2">
                                 <h3 className={`text-xl font-semibold transition-colors group-hover:text-${color}`}>{title}</h3>
-                                {count > 0 ? (
+                                {count !== 0 && (
                                     <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
-                                        {count}
-                                    </span>
-                                ) : (
-                                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
-                                        {'+'}
+                                        {count > 0 ? count : '+'}
                                     </span>
                                 )}
                             </div>

--- a/components/learning/devresource-grid.tsx
+++ b/components/learning/devresource-grid.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { resources } from "@/components/learning/resources"
 import FeatureCard from "../content-types/feature-card"
-
+import { GraduationCap } from "lucide-react"
 export function DevResourceGrid(count: any) {
 
   
@@ -43,6 +43,24 @@ export function DevResourceGrid(count: any) {
           </Link>
         )
       }})}
+
+      <Link 
+        key="lms" 
+        href={`https://dotcms.talentlms.com/plus/login`}
+        className="group"
+        prefetch={false}
+      >
+        <FeatureCard
+          href={`https://dotcms.talentlms.com/plus/login`}
+          icon={GraduationCap}
+          title={"Training & Courses"}
+          description={"Learn dotCMS with our comprehensive training courses"}
+          imageIdentifier={"/dA/68d9824f3e0afff7f637650a3a41dc2f/70q/1000maxw"}
+          color="[#a21caf]"
+          count={-1}
+          links={[]}
+        />
+      </Link>
     </div>
     </>
   )


### PR DESCRIPTION
Makayla requested the LMS be linked on the Learning page. Whereas this page generates its cards from content, and we don't have any content for that, I added a simple hard-coded entry copying the card style, with its own Lucide icon and external LMS link. Art asset supplied by Makayla.