### PR TITLE
fixed indent in yaml, added JAVA_TOOL_OPTIONS

### DIFF
--- a/components/releases/DockerComposeYAML/DockerComposeYAML.tsx
+++ b/components/releases/DockerComposeYAML/DockerComposeYAML.tsx
@@ -20,13 +20,13 @@ const DockerComposeYAML = (props: DockerComposeProps) => {
     const cleanStarterURL = `https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/empty_${cleanStarter}/starter-empty_${cleanStarter}.zip`
     const demoStarterURL = `https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/${demoStarter}/starter-${demoStarter}.zip`
     const outputYaml = `
-  # This Docker Compose file is used to spin up a local dotCMS container using Docker.
-  # Simply place this file in the desired working directory and run 'docker compose up' to get started.
-  # Version: ${version}${lts ? " LTS" : ""}
-  # Demo Site ${includeDemo ? "Included" : "Excluded"}
-  # Starter Image: ${includeDemo ? demoStarter : cleanStarter}
+# This Docker Compose file is used to spin up a local dotCMS container using Docker.
+# Simply place this file in the desired working directory and run 'docker compose up' to get started.
+# Version: ${version}${lts ? " LTS" : ""}
+# Demo Site ${includeDemo ? "Included" : "Excluded"}
+# Starter Image: ${includeDemo ? demoStarter : cleanStarter}
 
-  services:
+services:
   db:
     image: pgvector/pgvector:pg16
     command: postgres -c 'max_connections=400' -c 'shared_buffers=128MB'
@@ -76,6 +76,7 @@ const DockerComposeYAML = (props: DockerComposeProps) => {
     image: dotcms/dotcms:${dockerTag}
     environment:
       CMS_JAVA_OPTS: '-Xmx1g '
+      JAVA_TOOL_OPTIONS: '-XX:UseSVE=0'
       LANG: 'C.UTF-8'
       TZ: 'UTC'
       DB_BASE_URL: "jdbc:postgresql://db/dotcms"

--- a/components/releases/DockerComposeYAML/DockerComposeYAML.tsx
+++ b/components/releases/DockerComposeYAML/DockerComposeYAML.tsx
@@ -73,7 +73,7 @@ services:
           memory: 2G
 
   dotcms:
-    image: dotcms/dotcms:${dockerTag}
+    image: dotcms/dotcms:latest
     environment:
       CMS_JAVA_OPTS: '-Xmx1g '
       JAVA_TOOL_OPTIONS: '-XX:UseSVE=0'
@@ -88,7 +88,8 @@ services:
       DOT_DOTCMS_CLUSTER_ID: 'dotcms-production'
       GLOWROOT_ENABLED: 'true'
       GLOWROOT_WEB_UI_ENABLED: 'true' # Enable glowroot web ui on localhost.  do not use in production
-      CUSTOM_STARTER_URL: '${includeDemo ? demoStarterURL : cleanStarterURL}'
+
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - db
       - opensearch      
@@ -103,14 +104,14 @@ services:
       - "8443:8443"
       - "4000:4000" # Glowroot web ui if enabled
 
-  networks:
-    db_net:
-    opensearch-net:
+networks:
+  db_net:
+  opensearch-net:
 
-  volumes:
-    cms-shared:
-    dbdata:
-    opensearch-data:`;
+volumes:
+  cms-shared:
+  dbdata:
+  opensearch-data:`;
     const blob = new Blob([outputYaml], { type: 'text/yaml' });
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/components/releases/TableReleases/TableReleases.tsx
+++ b/components/releases/TableReleases/TableReleases.tsx
@@ -92,7 +92,7 @@ export const TableReleases: FC<{
           <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
               {downloadYAML && (
-                <th className="px-6 py-4 text-sm font-semibold text-gray-900 dark:text-gray-100">
+                <th className="px-12 py-4 text-sm font-semibold text-gray-900 dark:text-gray-100">
                 Download
               </th>
               )}
@@ -141,7 +141,7 @@ export const TableReleases: FC<{
                           demoStarter: release.starter, 
                           includeDemo: false 
                         })}}
-                        className="p-1 hover:bg-gray-100 dark:hover:bg-gray-600 
+                        className="px-1 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 w-0 grow
                                   rounded-md transition-colors bg-indigo-100 dark:bg-indigo-600"
                       >
                         Clean
@@ -155,10 +155,10 @@ export const TableReleases: FC<{
                             demoStarter: release.starter, 
                             includeDemo: true 
                           })}}
-                        className="p-1 hover:bg-gray-100 dark:hover:bg-gray-600 
+                        className="px-1 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 w-0 grow
                                   rounded-md transition-colors bg-purple-100 dark:bg-purple-600"
                       >
-                        With Demo Site
+                        Demo Site
                       </button>
                   </td>
                 )}


### PR DESCRIPTION
"Services must be a mapping" — turns out that line was wrongly indented, which threw things off.

Also added the `JAVA_TOOL_OPTIONS` discussed in thread here:
https://dotcms.slack.com/archives/C028Z3R2D/p1740417815932829?thread_ts=1740417749.517759&cid=C028Z3R2D