### PR TITLE
fixed string formatting on YAML

### DIFF
--- a/components/releases/DockerComposeYAML/DockerComposeYAML.tsx
+++ b/components/releases/DockerComposeYAML/DockerComposeYAML.tsx
@@ -73,7 +73,7 @@ services:
           memory: 2G
 
   dotcms:
-    image: dotcms/dotcms:latest
+    image: dotcms/dotcms:${dockerTag}
     environment:
       CMS_JAVA_OPTS: '-Xmx1g '
       JAVA_TOOL_OPTIONS: '-XX:UseSVE=0'
@@ -89,7 +89,7 @@ services:
       GLOWROOT_ENABLED: 'true'
       GLOWROOT_WEB_UI_ENABLED: 'true' # Enable glowroot web ui on localhost.  do not use in production
 
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
+      CUSTOM_STARTER_URL: '${includeDemo ? demoStarterURL : cleanStarterURL}'
     depends_on:
       - db
       - opensearch      


### PR DESCRIPTION
Previously fixed indent issues that were causing hell, and did so via copy/paste. I was so excited to have an orchestrator file that built, I missed that it also obliterated the string formatting elements.

This restores those.