### PR TITLE
Amnesty for parentheses, all criminal records expunged.

### DIFF
--- a/components/documentation/Documentation.js
+++ b/components/documentation/Documentation.js
@@ -19,9 +19,7 @@ function cleanMarkdown(markdownString, identifierString) {
     .replaceAll('src="/dA/', 'src="https://www.dotcms.com/dA/')
     .replaceAll("(/contentAsset", "(https://www.dotcms.com/contentAsset")
     .replaceAll("( /contentAsset", "(https://www.dotcms.com/contentAsset")
-    .replaceAll("<br>", "<br/>")
-    .replaceAll("()", "")
-    .replaceAll("</br>", "<br/>");
+    .replaceAll("</br>", "<br>");
 }
 
 const Documentation = ({ contentlet, sideNav, slug }) => {
@@ -51,7 +49,7 @@ const Documentation = ({ contentlet, sideNav, slug }) => {
           />
 
           <div className="markdown-content">
-            <h1 className="text-4xl font-bold mb-6 scroll-mt-20">{contentlet.title}</h1>
+            <h1 className="text-4xl font-bold mb-6">{contentlet.title}</h1>
             {contentlet.tag.includes("deprecated")  && (
               <div className="mb-6">
                 <Warn>


### PR DESCRIPTION
It is important to legislate with the greater good in mind! It's not clear to me why we would ever want to blanket-remove all instances of `()` from our docs, many of which have code examples that are rendered quite wrong without those!

I also pulled out some of the conversions from `<br>` to `<br/>`; HTML5 is back to our ancient friend `<br>`, so I see no reason to bother with extra replace calls.