### PR TITLE
Decollateralizing damages

### DIFF
--- a/components/AlertBanner.tsx
+++ b/components/AlertBanner.tsx
@@ -33,8 +33,19 @@ export function AlertBanner({
   if (!isVisible) return null;
 
   return (
-    <div className="bg-primary-purple text-white px-4 py-2 text-center text-sm">
-      {message}
+    <div className="sticky top-0 z-50 w-full">
+      <Alert className="rounded-none relative py-3 px-4 text-white border-none" style={{ backgroundColor: 'rgb(24, 24, 109)' }}>
+        <AlertDescription className="text-white w-full text-center">
+          {message}
+        </AlertDescription>
+        <button
+          onClick={dismissBanner}
+          className="p-1 absolute right-4 top-1/2 transform -translate-y-1/2 rounded-full hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          aria-label="Close alert"
+        >
+          <X className="h-4 w-4 text-white" />
+        </button>
+      </Alert>
     </div>
   );
 }


### PR DESCRIPTION
In  https://github.com/dotCMS/new-new-devsite/pull/118, there was a bit of collateral damage; Claude got a little TOO excited and tweaked the alert banner. At first I thought the only change was a color shift, which seemed odd, since none of the CSS would have implied such. But I was like "this seems like a lateral move" and left it. 

Only after it merged did I notice that these changes also removed the ability to dismiss the banner.

So, this PR represents pulling the Alert banner from the previous PR diff and restoring it in full to its original state. Doesn't seem to create too much strife with the other changes contained therein.