### PR TITLE
remove some bad doc from index

### DIFF
--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,3 +1,7 @@
 User-Agent: *
-Allow: /
+allow: /
+disallow: /docs/elasticsearch-queries
+disallow: /docs/markdown-syntax
+disallow: /docs/active-directory-error-codes
+
 Sitemap: https://dev.dotcms.com/sitemap.xml


### PR DESCRIPTION
This pull request includes changes to the `robots.txt` file to update the rules for web crawlers. The most important changes include allowing all user agents to access the site, but disallowing access to specific documentation pages.

Changes to `robots.txt`:

* Updated the `Allow` directive to `allow` to correct the case.
* Added `disallow` directives to restrict access to `/docs/elasticsearch-queries`, `/docs/markdown-syntax`, and `/docs/active-directory-error-codes`.