### PR TITLE
added `toLowerCase()` to slug collection

### DIFF
--- a/app/docs/[slug]/page.js
+++ b/app/docs/[slug]/page.js
@@ -49,7 +49,7 @@ async function fetchPageData(path, searchParams) {
 export async function generateMetadata({ params, searchParams }) {
     const finalParams = await params;
     const finalSearchParams = await searchParams;
-    const slug = finalParams.slug;
+    const slug = finalParams.slug.toLowerCase();
     const path = "/docs/" + (slug || "table-of-contents");
     const hostname = "https://dev.dotcms.com";
     const { pageAsset } = await fetchPageData(path, finalSearchParams);
@@ -159,7 +159,7 @@ export default async function Home({ searchParams, params }) {
     const finalSearchParams = await searchParams;
 
     const resetNav = finalSearchParams.n === "0";
-    const slug = finalParams.slug;
+    const slug = finalParams.slug.toLowerCase();
     const path = "/docs/" + (slug || "table-of-contents");
     const hostname = "https://dev.dotcms.com";
     const { pageAsset, sideNav } = await fetchPageData(path, finalSearchParams);


### PR DESCRIPTION
This avoids routing to contentlets in place of component-pages. For example, some links in the wild to `/changeLogs` would route to this:

![image](https://github.com/user-attachments/assets/1f003254-8847-43c5-a791-91855425e1c2)

...instead of the actual changelogs page.