### PR TITLE
removes unneeded prose-lg

### DIFF
--- a/components/content-types/webPageContent.tsx
+++ b/components/content-types/webPageContent.tsx
@@ -10,7 +10,7 @@ const WebPageContent: React.FC<WebPageContentProps> = ({ title, body }) => {
   return (
     <article className="w-full">
       <h1 className="text-3xl font-bold mb-6 text-primary">{title}</h1>
-      <div className="prose prose-lg max-w-none">
+      <div className="prose  max-w-none">
       {isJSON(body) ? (
         <DotBlockEditor  
           blocks={typeof body === 'string' ? JSON.parse(body) : body}

--- a/components/page-asset-with-content-block.js
+++ b/components/page-asset-with-content-block.js
@@ -62,7 +62,7 @@ export function BlockPageAsset({ pageAsset, nav, serverPath }) {
             <h1 className="text-4xl font-bold mb-6">{pageAsset.page.title}</h1>
 
             {hasBlockContent && (
-              <div className="prose prose-lg mb-8">
+              <div className="prose mb-8">
                   <DotBlockEditor blocks={pageAsset.page.content} customRenderers={{}} />
               </div>
             )}


### PR DESCRIPTION
This pull request makes minor updates to the styling of `div` elements containing rich text content by removing the `prose-lg` class in two components. These changes ensure consistent styling across the application.

Styling updates:

* In `components/content-types/webPageContent.tsx`, the `prose-lg` class was removed from the `div` wrapping the `DotBlockEditor` to standardize the appearance of rich text content.
* In `components/page-asset-with-content-block.js`, the `prose-lg` class was removed from the `div` wrapping the `DotBlockEditor` when rendering block content.