### PR TITLE
Fixing text & link color && adjusting bullet point spacing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,6 +88,14 @@
   body {
     @apply antialiased bg-background text-foreground;
   }
+
+  /* Adding these to make short list items a bit less spacey*/
+  li > p:first-child {
+    margin-top: 0;
+  }
+  li > p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 
@@ -131,3 +139,4 @@ main {
 .swagger-ui .model-toggle:after {
   background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\"http://www.w3.org/2000/svg\" style=\"fill:gray;\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\"><path d=\"M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z\"/></svg>") 50% no-repeat !important;
 }
+

--- a/components/content-types/webPageContent.tsx
+++ b/components/content-types/webPageContent.tsx
@@ -10,7 +10,7 @@ const WebPageContent: React.FC<WebPageContentProps> = ({ title, body }) => {
   return (
     <article className="w-full">
 
-      <div className="prose  max-w-none">
+      <div className="prose dark:prose-invert max-w-none">
       {isJSON(body) ? (
         <DotBlockEditor  
           blocks={typeof body === 'string' ? JSON.parse(body) : body}

--- a/components/page-asset-with-content-block.js
+++ b/components/page-asset-with-content-block.js
@@ -62,7 +62,7 @@ export function BlockPageAsset({ pageAsset, nav, serverPath }) {
             <h1 className="text-4xl font-bold mb-6">{pageAsset.page.title}</h1>
 
             {hasBlockContent && (
-              <div className="prose mb-8">
+              <div className="prose dark:prose-invert mb-8">
                   <DotBlockEditor blocks={pageAsset.page.content} customRenderers={{}} />
               </div>
             )}

--- a/components/shared/dotBlockEditor.js
+++ b/components/shared/dotBlockEditor.js
@@ -47,14 +47,14 @@ const LinkMark = ({ children, attrs }) => {
   if (relative) {
     // If the URL fails it is likely a relative URL
     return (
-      <Link {...attrs} href={href || "/"}>
+      <Link {...attrs} href={href || "/"} className="text-primary-purple hover:opacity-80 underline hover:no-underline">
         {children}
       </Link>
     );
   }
 
   return (
-    <a {...attrs} href={href}>
+    <a {...attrs} href={href} className="text-primary-purple hover:opacity-80 underline hover:no-underline">
       {children}
     </a>
   );


### PR DESCRIPTION
A recent merge dramatically darkened the dark-mode text in the Getting Started section. This fixes that. Also sharpshoots links in blocks with the expected classes.

Finally, I felt the bullet points were spread kinda far apart, since they combined both the `<li>` margins and the `<p>` margins. So now, the first and last paragraph inside a list item will have a zeroed margin-top and margin-bottom, respectively; if they're both the same paragraph, no paragraph margins at all.