### PR TITLE
fixed error with LTS with enough minor versions to paginate

### DIFF
--- a/components/changelogs/ChangeLogList.js
+++ b/components/changelogs/ChangeLogList.js
@@ -158,8 +158,13 @@ export default function ChangeLogContainer({ sideNav, slug }) {
                   }
                 })();
                 // just to convey the Designation/EOL dates for the entire page
-                thisMajorVersion = data.ltsMajors[ltsMajorVersions.indexOf(vLts)].parent ? 
-                  data.ltsMajors[ltsMajorVersions.indexOf(vLts)].parent : data.ltsMajors[ltsMajorVersions.indexOf(vLts)];
+                const vLtsIndex = ltsMajorVersions.indexOf(vLts);
+                if (vLtsIndex !== -1 && data.ltsMajors && data.ltsMajors[vLtsIndex]) {
+                  thisMajorVersion = data.ltsMajors[vLtsIndex].parent ? 
+                    data.ltsMajors[vLtsIndex].parent : data.ltsMajors[vLtsIndex];
+                } else {
+                  thisMajorVersion = null;
+                }
                 return (
                   <Dropdown 
                     items={ltsMajorVersions}
@@ -173,7 +178,7 @@ export default function ChangeLogContainer({ sideNav, slug }) {
         </div>
 
         {
-          isLts && (() => {
+          isLts && thisMajorVersion && (() => {
             return (
               <div className="text-foreground flex items-center text-xl font-semibold justify-between">
                 <div>Designated: {extractDateForTables(thisMajorVersion.releasedDate)}</div>

--- a/services/docs/getChangelog/getChangelog.ts
+++ b/services/docs/getChangelog/getChangelog.ts
@@ -91,7 +91,7 @@ export const getChangelog = async ({ page = 1, vLts = "false", singleVersion = "
   const ltsMajVersion = sussOutLatestMajor(ltsMajorData.DotcmsbuildsCollection[0], vLts);
   //console.log("sussed as:", ltsMajVersion);
   const sortBy = 'Dotcmsbuilds.releasedDate desc';
-  const query = assembleQuery(buildQuery, ltsQuery, ltsMajVersion, (singleVersion && !ltsPatchVersion) ? `+Dotcmsbuilds.minor:${singleVersion}` : "", (ltsMajVersion ? 25 : limit), page, sortBy);
+  const query = assembleQuery(buildQuery, ltsQuery, ltsMajVersion, (singleVersion && !ltsPatchVersion) ? `+Dotcmsbuilds.minor:${singleVersion}` : "", (ltsMajVersion ? 20 : limit), page, sortBy);
   const data = await logRequest(async () => getGraphqlResults(query), 'getChangelog');
 
   return {changelogs: data.DotcmsbuildsCollection, pagination: data.Pagination[0], ltsMajors: ltsMajorData.DotcmsbuildsCollection, ltsSingleton: ltsPatchVersion};


### PR DESCRIPTION
Lowered the number of minor versions per page from 25 to 20, then fixed a bug that would cause failure on pagination due to improper handling of parent property.