### PR TITLE
Adjust height calculation for better "Older" link visibility

### DIFF
--- a/components/changelogs/ChangeLogList.js
+++ b/components/changelogs/ChangeLogList.js
@@ -207,7 +207,7 @@ export default function ChangeLogContainer({ sideNav, slug }) {
                 [&::-webkit-scrollbar-thumb]:bg-muted-foreground/10
                 [&::-webkit-scrollbar-thumb]:rounded-full
                 hover:[&::-webkit-scrollbar-thumb]:bg-muted-foreground/20
-                h-[calc(100vh-4rem)]">
+                h-[calc(100vh-6rem)]">
             {hasPrevPage && (
               <a
                 title="Newer Releases"


### PR DESCRIPTION
There was an inaccuracy in the scroll-height calculation on the right sidebar. As such, when the window was small enough, it would stop scrolling just before hitting the "Older" link, when there are enough versions to paginate.

Single-character fix.