### PR TITLE
fixed nav scroll position save overtaking autoscroll

### DIFF
--- a/components/navigation/NavTree.tsx
+++ b/components/navigation/NavTree.tsx
@@ -79,7 +79,7 @@ const NavTree = React.memo(
       // Restore scroll position immediately
       navElement.scrollTop = savedScroll;
       setIsInitialSetupComplete(true);
-    }, [savedScroll, isMobile]);
+    }, [isMobile]);
 
     // Helper function to find active link with flexible matching
     const findActiveLink = useCallback((navElement: HTMLElement) => {


### PR DESCRIPTION
All the tests on localhost played out correctly, but once it was on vercel, that changed. So this attempts to fix the race condition by procedurally ensuring the scroll pos restore occurs before the autoscroll.