### PR TITLE
Fixing those old hydration errors

### DIFF
--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -224,11 +224,11 @@ export default function Header({ sideNavItems, currentPath }: HeaderProps) {
             </Link>
           </NavigationMenuItem>
           <NavigationMenuItem>
-            <a href="https://community.dotcms.com/" target="dotCMSCommunity">
-              <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+            <NavigationMenuLink asChild>
+              <a href="https://community.dotcms.com/" target="dotCMSCommunity" className={navigationMenuTriggerStyle()}>
                 Community <ExternalLink className="h-3 w-3 inline-block ml-1" />
-              </NavigationMenuLink>
-            </a>
+              </a>
+            </NavigationMenuLink>
           </NavigationMenuItem>
         </NavigationMenuList>
       </NavigationMenu>

--- a/components/navigation/NavTree.tsx
+++ b/components/navigation/NavTree.tsx
@@ -68,10 +68,15 @@ const NavTree = React.memo(
     // Handle navigation reset on client-side only
     useEffect(() => {
       if (resetNav && typeof window !== "undefined" && window.localStorage) {
+        // Clear localStorage
         window.localStorage.setItem(NAV_STORAGE_KEY, JSON.stringify([]));
         window.localStorage.setItem(SCROLL_STORAGE_KEY, JSON.stringify(0));
+        
+        // Reset component state to default values
+        setOpenSections([]);
+        setSavedScroll(0);
       }
-    }, [resetNav]);
+    }, [resetNav, setOpenSections, setSavedScroll]);
 
     // Restore saved scroll position on mount, then enable auto-centering
     useEffect(() => {

--- a/components/navigation/NavTree.tsx
+++ b/components/navigation/NavTree.tsx
@@ -23,19 +23,26 @@ type NavTreeProps = {
 };
 
 function useStickyState(defaultValue: any, name: string) {
-  const [value, setValue] = useState(() => {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return defaultValue;
-    }
+  const [value, setValue] = useState(defaultValue);
+  const [isHydrated, setIsHydrated] = useState(false);
 
-    const persistedValue = window.localStorage.getItem(name);
-
-    return persistedValue !== null ? JSON.parse(persistedValue) : defaultValue;
-  });
-
+  // Load from localStorage after hydration
   useEffect(() => {
-    window.localStorage.setItem(name, JSON.stringify(value));
-  }, [name, value]);
+    if (typeof window !== "undefined" && window.localStorage) {
+      const persistedValue = window.localStorage.getItem(name);
+      if (persistedValue !== null) {
+        setValue(JSON.parse(persistedValue));
+      }
+    }
+    setIsHydrated(true);
+  }, [name]);
+
+  // Save to localStorage when value changes (but only after hydration)
+  useEffect(() => {
+    if (isHydrated && typeof window !== "undefined" && window.localStorage) {
+      window.localStorage.setItem(name, JSON.stringify(value));
+    }
+  }, [name, value, isHydrated]);
 
   return [value, setValue];
 }

--- a/components/navigation/NavTree.tsx
+++ b/components/navigation/NavTree.tsx
@@ -51,11 +51,6 @@ const NavTree = React.memo(
   ({ items, nav, currentPath = "", level = 0, isMobile = false,resetNav = false }: NavTreeProps) => {
     // Debug the nav structure in detail
 
-    if(resetNav) {  
-        window.localStorage.setItem(NAV_STORAGE_KEY, JSON.stringify([]));
-        window.localStorage.setItem(SCROLL_STORAGE_KEY, JSON.stringify(0)); 
-      }
-
     const [openSections, setOpenSections] = useStickyState([], NAV_STORAGE_KEY);
     const [savedScroll, setSavedScroll] = useStickyState(0, SCROLL_STORAGE_KEY);
     const [isInitialSetupComplete, setIsInitialSetupComplete] = useState(false);
@@ -69,6 +64,14 @@ const NavTree = React.memo(
         timeoutRefs.current.clear();
       };
     }, []);
+
+    // Handle navigation reset on client-side only
+    useEffect(() => {
+      if (resetNav && typeof window !== "undefined" && window.localStorage) {
+        window.localStorage.setItem(NAV_STORAGE_KEY, JSON.stringify([]));
+        window.localStorage.setItem(SCROLL_STORAGE_KEY, JSON.stringify(0));
+      }
+    }, [resetNav]);
 
     // Restore saved scroll position on mount, then enable auto-centering
     useEffect(() => {


### PR DESCRIPTION
Those old unsightly React errors are now much easier to solve: One required knowing about the `asChild` prop on the Radix menu component, and the other required adding a `useEffect` `isHydrated` check before reaching into localStorage.