### PR TITLE
avoids ._map related errors on vanity url redirects

### DIFF
--- a/app/docs/[slug]/page.js
+++ b/app/docs/[slug]/page.js
@@ -187,9 +187,12 @@ export default async function Home({ searchParams, params }) {
     const hostname = "https://dev.dotcms.com";
     const { pageAsset, sideNav } = await fetchPageData(path, finalSearchParams);
     
-    // Handle vanity URL redirect before trying to access urlContentMap
+    // Handle vanity URL redirect - this should redirect and not continue execution
     if (pageAsset?.page?.vanityUrl) {
         handleVanityUrlRedirect(pageAsset?.page?.vanityUrl);
+        // If we reach here, the redirect didn't work as expected
+        // Return null or a loading state instead of continuing
+        return null;
     }
     
     // Check if urlContentMap exists before accessing _map


### PR DESCRIPTION
This fix addresses some vanity URLs not behaving properly, due to trying to access `pageAsset.urlContentMap._map` when `pageAsset.urlContentMap` is null. 

A similar bug was fixed in dotCMS itself, allowing vanity URLs to function even when no contentlet exists for the initial target. But I guess a similar gap existed in the front-end code, here.