### PR TITLE
make vanity behavior consistent between app/... && app/docs/...

### DIFF
--- a/app/[[...slug]]/page.js
+++ b/app/[[...slug]]/page.js
@@ -26,6 +26,16 @@ export async function generateMetadata({ params, searchParams }) {
     try {
         const data = await client.page.get(pageRequestParams);
         const page = data.page;
+        
+        // Check for vanity URL redirect first
+        if (page?.vanityUrl) {
+            // Return minimal metadata for vanity URLs since they'll redirect anyway
+            return {
+                title: "Redirecting...",
+                description: "Page is being redirected"
+            };
+        }
+        
         const title = page?.friendlyName || page?.title;
 
         const description = page?.description || page?.teaser || page?.seoDescription || "dotCMS Dev Site, Documentation and Resources. Learn how to build with dotCMS";
@@ -89,8 +99,11 @@ export default async function Page({ params, searchParams }) {
         return <ErrorPage error={{ message: "Page not found", status: 404 }} />;
     }
 
-    if (pageAsset?.vanityUrl) {
-        handleVanityUrlRedirect(pageAsset?.vanityUrl);
+    if (pageAsset?.page?.vanityUrl) {
+        handleVanityUrlRedirect(pageAsset?.page?.vanityUrl);
+        // If we reach here, the redirect didn't work as expected
+        // Return null or a loading state instead of continuing
+        return null;
     }
     const isBlockPage = pageAsset?.page?.contentType==="BlockPage"
     if(isBlockPage) {


### PR DESCRIPTION
We were looking in two different places for the vanity URL between `app/[[...slug]]` and `app/docs/[[...slug]]`. This sets them alike and avoids inconsistent routing behavior.