### PR TITLE
Make nav titles prefer navTitle to title

### DIFF
--- a/components/navigation/NavTree.tsx
+++ b/components/navigation/NavTree.tsx
@@ -208,7 +208,7 @@ const NavTree = React.memo(
               <div key={item.title} className="mb-5">
                 <div className="py-1 px-2 font-semibold text-foreground">
                     <Link href={item.urlTitle} prefetch={false} className="flex items-center gap-2 hover:text-primary-purple">
-                            {item.title}
+                            {item.navTitle || item.title}
                     </Link>
                 </div>
                 <SubNavTree
@@ -230,7 +230,7 @@ const NavTree = React.memo(
                   <div key={item.title || Math.random()} className="mb-5">
                     <div className="py-2 px-3 font-semibold bg-gray-50 rounded-md text-foreground border border-gray-200">
                         <Link href={item.href || "#"} prefetch={false} className="flex items-center gap-2 hover:text-primary-purple">
-                                {item.title || "Unnamed Link"}
+                                {item.navTitle || item.title || "Unnamed Link"}
                         </Link>
                         <div className="text-xs text-gray-500 mt-1">
                           href: {item.href || "none"}

--- a/components/navigation/SubNavTree.tsx
+++ b/components/navigation/SubNavTree.tsx
@@ -54,10 +54,11 @@ const SubNavTree = React.memo(({ items=[], currentPath, level = 0, openSections,
     expandCurrentSection(items, []);
   }, [items, relevantPath, setOpenSections]);
 
-  const renderNavItem = useCallback((item: { urlTitle: string; title: string; dotcmsdocumentationchildren?: any[] }) => {
+  const renderNavItem = useCallback((item: { urlTitle: string; title: string; navTitle?: string; dotcmsdocumentationchildren?: any[] }) => {
     const isCurrentPage = item.urlTitle === relevantPath;
     const hasChildren = item.dotcmsdocumentationchildren && item.dotcmsdocumentationchildren.length > 0;
     const paddingY = 'py-1.5';
+    const displayTitle = item.navTitle || item.title;
 
     if (hasChildren) {
       return (
@@ -85,7 +86,7 @@ const SubNavTree = React.memo(({ items=[], currentPath, level = 0, openSections,
                   toggleSection(item.urlTitle);
                 }}
               >
-                {item.title}
+                {displayTitle}
               </Link>
               <CollapsibleTrigger className="p-0">
                 <ChevronRight
@@ -123,7 +124,7 @@ const SubNavTree = React.memo(({ items=[], currentPath, level = 0, openSections,
               : "text-muted-foreground hover:bg-muted hover:text-foreground"
           )}
         >
-          {item.title}
+          {displayTitle}
         </Link>
       );
     }

--- a/services/docs/getSideNav.ts
+++ b/services/docs/getSideNav.ts
@@ -16,30 +16,37 @@ export const getSideNav = async () => {
     query Documents {
         DotcmsDocumentationCollection(query: "+DotcmsDocumentation.urlTitle_dotraw:table-of-contents") {
             title
+            navTitle
             urlTitle
             modDate
             dotcmsdocumentationchildren {
                 title
+                navTitle
                 urlTitle
                 modDate
                 dotcmsdocumentationchildren {
                     title
+                    navTitle
                     urlTitle
                     modDate
                     dotcmsdocumentationchildren {
                         title
+                        navTitle
                         urlTitle
                         modDate
                         dotcmsdocumentationchildren {
                             title
+                            navTitle
                             urlTitle
                             modDate
                             dotcmsdocumentationchildren {
                                 title
+                                navTitle
                                 urlTitle
                                 modDate
                                 dotcmsdocumentationchildren {
                                     title
+                                    navTitle
                                     urlTitle
                                     modDate
                                 }


### PR DESCRIPTION
This change adds `navTitle` to the query to fetch nav data, and then instructs the left-nav components to prefer the `navTitle` property to the `title` property, when available.