### PR TITLE
endpoint tweaks: demo page, code block detection

### DIFF
--- a/app/test-components/page.tsx
+++ b/app/test-components/page.tsx
@@ -22,7 +22,8 @@ Dropping this component directly into your markdown content:
 \`<Endpoint method="GET" path="/api/v1/contenttype" />\`
 
 \`<Endpoint method="GET" path="/api/v1/contenttype" />
-a\'
+
+a\`
 
 \`<Endpoint method="GET" path="/api/v1/contenttype" />\`
 

--- a/app/test-components/page.tsx
+++ b/app/test-components/page.tsx
@@ -12,21 +12,8 @@ Demoing the new SwaggerUI-style API endpoint block component:
 Dropping this component directly into your markdown content:
 
 \`\`\`markdown
-\`\` d \'<Endpoint method="GET" path="/api/v1/contenttype" /> \` d \`\`
-\`\`\`
-
-\`\`\`markdown
 <Endpoint method="GET" path="/api/v1/contenttype" />
 \`\`\`
-
-\`<Endpoint method="GET" path="/api/v1/contenttype" />\`
-
-\`<Endpoint method="GET" path="/api/v1/contenttype" />
-
-a\`
-
-\`<Endpoint method="GET" path="/api/v1/contenttype" />\`
-
 
 Will give this output:
 

--- a/app/test-components/page.tsx
+++ b/app/test-components/page.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import MarkdownContent from '@/components/MarkdownContent'
+
+const markdownContent = `
+# Block Components Test Page
+
+Demoing the new SwaggerUI-style API endpoint block component:
+
+## API Endpoints
+
+Dropping this component directly into your markdown content:
+
+\`\`\`markdown
+<Endpoint method="GET" path="/api/v1/contenttype" />
+\`\`\`
+
+Will give this output:
+
+<Endpoint method="GET" path="/api/v1/contenttype" />
+
+And lo, I can put text in between them!
+
+<Endpoint method="POST" path="/api/v1/workflow/steps" />
+
+Also all the **normal *markdown*** stuff [works](https://www.google.com) too!
+
+<Endpoint method="PUT" path="/api/v1/workflow/steps/{stepId}" />
+
+<Endpoint method="DELETE" path="/api/v1/contenttype/id/{idOrVar}" />
+
+<Endpoint method="GET" path="/api/v1/site" />
+
+## Info, Warning boxes
+
+<Info>
+The Info component works as expected!
+</Info>
+
+<Warn>
+And the Warn component too!
+</Warn>
+
+## Code Examples
+
+Here's how easy it is to use:
+
+\`\`\`markdown
+<!-- Basic endpoint (collapsed, read-only) -->
+<Endpoint method="GET" path="/api/v1/content" />
+
+<!-- Show the tag/category -->
+<Endpoint method="POST" path="/api/v1/content" showTag={true} />
+
+<!-- Enable interactive "Try it out" -->
+<Endpoint method="PUT" path="/api/v1/content/{id}" tryItOut={true} />
+
+<!-- Both tag and try it out -->
+<Endpoint method="DELETE" path="/api/v1/content/{id}" showTag={true} tryItOut={true} />
+\`\`\`
+
+The component automatically:
+- Fetches the OpenAPI specification
+- Finds the endpoint details
+- Renders a complete SwaggerUI-style documentation block
+- Starts collapsed and read-only unless configured otherwise
+`;
+
+export default function TestComponentsPage() {
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <MarkdownContent content={markdownContent} />
+    </div>
+  )
+} 

--- a/app/test-components/page.tsx
+++ b/app/test-components/page.tsx
@@ -12,8 +12,20 @@ Demoing the new SwaggerUI-style API endpoint block component:
 Dropping this component directly into your markdown content:
 
 \`\`\`markdown
+\`\` d \'<Endpoint method="GET" path="/api/v1/contenttype" /> \` d \`\`
+\`\`\`
+
+\`\`\`markdown
 <Endpoint method="GET" path="/api/v1/contenttype" />
 \`\`\`
+
+\`<Endpoint method="GET" path="/api/v1/contenttype" />\`
+
+\`<Endpoint method="GET" path="/api/v1/contenttype" />
+a\'
+
+\`<Endpoint method="GET" path="/api/v1/contenttype" />\`
+
 
 Will give this output:
 

--- a/components/block-components-system.tsx
+++ b/components/block-components-system.tsx
@@ -43,10 +43,10 @@ function isInsideCodeBlock(content: string, position: number): boolean {
     let inInlineCode = false;
     let inlineCodeDelimiter = '';
     
-    // Check for indented code blocks (4+ spaces at start of line)
+    // Check for indented code blocks (4+ spaces OR tab at start of line)
     // Only valid if not already in other code blocks
     if (!inFencedBlock && !inInlineCode) {
-      const isIndented = line.match(/^    /);
+      const isIndented = line.match(/^(    |\t)/);
       const isBlankLine = line.trim() === '';
       
       if (isIndented && !isBlankLine) {

--- a/components/block-components-system.tsx
+++ b/components/block-components-system.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 import { visit } from 'unist-util-visit';
+////////////////////////////////////////////////////////////
+// NOTE: If we have any further problems with code delimiter parsing, I vote we switch 
+//        to remark-parse rather than persisting in further reinventions of the wheel.
+//  import { unified } from 'unified';
+//  import remarkParse from 'remark-parse';
+////////////////////////////////////////////////////////////
 import Info from '@/components/mdx/Info';
 import Warn from '@/components/mdx/Warn';
 import Endpoint from '@/components/mdx/Endpoint';

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,11 +76,13 @@
         "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.0",
+        "remark-parse": "^11.0.0",
         "sonner": "^1.5.0",
         "swagger-ui-react": "^5.18.3",
         "tailwind-merge": "^2.5.2",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.3.3",
+        "unified": "^11.0.5",
         "vaul": "^0.9.9",
         "zod": "^3.23.8"
       },
@@ -9854,6 +9856,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -11203,6 +11206,7 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -77,11 +77,13 @@
     "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.0",
+    "remark-parse": "^11.0.0",
     "sonner": "^1.5.0",
     "swagger-ui-react": "^5.18.3",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
+    "unified": "^11.0.5",
     "vaul": "^0.9.9",
     "zod": "^3.23.8"
   },


### PR DESCRIPTION
This makes a few small changes.

- The block components system, which allows custom component design for use within markdown docs, now performs detection to make sure code blocks are not preprocessed as components.
- Added demo page to show off the `<Endpoint />` component (this will be removed once it's in regular use)
- Removed remaining vestiges of `<Note>` component originally created to test the block components system.