### PR TITLE
Deleted mode from request params

### DIFF
--- a/app/[[...slug]]/page.js
+++ b/app/[[...slug]]/page.js
@@ -66,12 +66,10 @@ export async function generateMetadata({ params, searchParams }) {
 
 export default async function Page({ params, searchParams }) {
     const finalParams = await params;
-    const finalSearchParams = await searchParams;
+    // We dont need send the mode on the params
+    const { mode, ...finalSearchParams } = await searchParams;
     const headersList = await headers();
     const pathname = headersList.get("x-invoke-path") || "";
-
-    // We dont need send the mode on the params
-    delete finalSearchParams.mode;
     
     const getPageData = async () => {
         const path = finalParams?.slug?.join("/") || "/";

--- a/app/[[...slug]]/page.js
+++ b/app/[[...slug]]/page.js
@@ -70,6 +70,9 @@ export default async function Page({ params, searchParams }) {
     const headersList = await headers();
     const pathname = headersList.get("x-invoke-path") || "";
 
+    // We dont need send the mode on the params
+    delete finalSearchParams.mode;
+    
     const getPageData = async () => {
         const path = finalParams?.slug?.join("/") || "/";
         const pageParams = getPageRequestParams({


### PR DESCRIPTION

https://github.com/user-attachments/assets/956befcb-e7e6-4f11-b310-b5ff175f8ac6

This PR delete the param "mode" from page api request. This attribute is not needed because that info is always in LIVE mode, and inside UVE is received from the UVE Editor