### PR TITLE
Adding sdk example gh entries

### DIFF
--- a/components/documentation/GitHubDocumentation.js
+++ b/components/documentation/GitHubDocumentation.js
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { ExternalLink, Github } from "lucide-react";
+import { ExternalLink, Github, Zap } from "lucide-react";
 
 import Breadcrumbs from "@/components/navigation/Breadcrumbs";
 import MarkdownContent from "@/components/MarkdownContent";
@@ -54,21 +54,46 @@ const GitHubDocumentation = ({ contentlet, sideNav, slug }) => {
             {/* GitHub Source Alert */}
             <div className="not-markdown">
               <Alert className="mb-6">
-                <Github className="h-4 w-4" />
-                <AlertDescription className="flex items-center justify-between">
-                  <span>
-                    This documentation is automatically synchronized from the{" "}
-                    <strong>{githubConfig.repo}</strong> repository.
-                  </span>
-                  <a
-                    href={githubLibraryUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
-                  >
-                    View on GitHub
-                    <ExternalLink className="h-3 w-3" />
-                  </a>
+                <AlertDescription>
+                  <div className="flex items-start gap-2">
+                    <Github className="h-4 w-4 mt-0.5 shrink-0" />
+                    <div className="flex items-center justify-between w-full">
+                      <span className="text-sm">
+                        This documentation is automatically synchronized from the{" "}
+                        <strong>{githubConfig.repo}</strong> repository.
+                      </span>
+                      <a
+                        href={githubLibraryUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline whitespace-nowrap ml-4"
+                      >
+                        View on GitHub
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
+                  </div>
+                  {githubConfig.starterGuide && (
+                    <div className="mt-3 pt-3 border-t border-border/50">
+                      <div className="flex items-start gap-2">
+                        <Zap className="h-4 w-4 mt-0.5 shrink-0" />
+                        <div className="flex items-center justify-between w-full">
+                          <span className="text-sm">
+                            Get started quickly with detailed instructions and visual aids.
+                          </span>
+                          <a
+                            href={githubConfig.starterGuide}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline whitespace-nowrap ml-4"
+                          >
+                            View Integration Guide
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </AlertDescription>
               </Alert>
             </div>

--- a/config/github-docs.ts
+++ b/config/github-docs.ts
@@ -62,6 +62,42 @@ export const GITHUB_DOCS_MAP: Record<string, GitHubConfig> = {
     path: 'README.md',
     branch: 'main'
   },
+  'sdk-nextjs-example': {
+    owner: 'dotCMS',
+    repo: 'core',
+    path: 'examples/nextjs/README.md',
+    branch: 'main'
+  },
+  'sdk-angular-example': {
+    owner: 'dotCMS',
+    repo: 'core',
+    path: 'examples/angular/README.md',
+    branch: 'main'
+  },
+  'sdk-astro-example': {
+    owner: 'dotCMS',
+    repo: 'core',
+    path: 'examples/astro/README.md',
+    branch: 'main'
+  },
+  'sdk-laravel-example': {
+    owner: 'dotCMS',
+    repo: 'dotcms-php-sdk',
+    path: 'examples/dotcms-laravel/README.md',
+    branch: 'main'
+  },
+  'sdk-symfony-example': {
+    owner: 'dotCMS',
+    repo: 'dotcms-php-sdk',
+    path: 'examples/dotcms-symfony/README.md',
+    branch: 'main'
+  },
+  'sdk-dotnet-example': {
+    owner: 'dotCMS',
+    repo: 'dotnet-starter-example',
+    path: 'README.md',
+    branch: 'main'
+  },
   // Add more SDK mappings as needed
 };
 

--- a/config/github-docs.ts
+++ b/config/github-docs.ts
@@ -6,6 +6,7 @@ export interface GitHubConfig {
   repo: string;
   path: string;
   branch: string;
+  starterGuide?: string;
 }
 
 /**
@@ -18,13 +19,14 @@ export const GITHUB_DOCS_MAP: Record<string, GitHubConfig> = {
     owner: 'dotCMS',
     repo: 'core',
     path: 'core-web/libs/sdk/react/README.md',
-    branch: 'main'
+    branch: 'main',
   },
   'sdk-angular-library': {
     owner: 'dotCMS',
     repo: 'core',
     path: 'core-web/libs/sdk/angular/README.md',
-    branch: 'main'
+    branch: 'main',
+    starterGuide: '/getting-started/integrations/angular'
   },
   'sdk-client-library': {
     owner: 'dotCMS',
@@ -66,31 +68,36 @@ export const GITHUB_DOCS_MAP: Record<string, GitHubConfig> = {
     owner: 'dotCMS',
     repo: 'core',
     path: 'examples/nextjs/README.md',
-    branch: 'main'
+    branch: 'main',
+    starterGuide: '/getting-started/integrations/nextjs'
   },
   'sdk-angular-example': {
     owner: 'dotCMS',
     repo: 'core',
     path: 'examples/angular/README.md',
-    branch: 'main'
+    branch: 'main',
+    starterGuide: '/getting-started/integrations/angular'
   },
   'sdk-astro-example': {
     owner: 'dotCMS',
     repo: 'core',
     path: 'examples/astro/README.md',
-    branch: 'main'
+    branch: 'main',
+    starterGuide: '/getting-started/integrations/astro'
   },
   'sdk-laravel-example': {
     owner: 'dotCMS',
     repo: 'dotcms-php-sdk',
     path: 'examples/dotcms-laravel/README.md',
-    branch: 'main'
+    branch: 'main',
+    starterGuide: '/getting-started/integrations/laravel'
   },
   'sdk-symfony-example': {
     owner: 'dotCMS',
     repo: 'dotcms-php-sdk',
     path: 'examples/dotcms-symfony/README.md',
-    branch: 'main'
+    branch: 'main',
+    starterGuide: '/getting-started/integrations/symfony'
   },
   'sdk-dotnet-example': {
     owner: 'dotCMS',


### PR DESCRIPTION
Added 6 new pages to the automatically synchronized GitHub README pages:

- Next.js Example
- Angular Example
- Astro Example
- Laravel Example
- Symfony Example
- .NET Example

Additionally, I added a new optional prop to this functionality: `starterGuide`. If you include it, the page will include at the top a link to its Getting Started integration guide.