### PR TITLE
Add neglected img component to markdown rendering

### DIFF
--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -274,6 +274,15 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content, className, d
     },
     hr: () => <hr className="border-t border-border mb-6" />,
 
+    img: ({ src, alt, ...props }: any) => (
+      <img 
+        src={src} 
+        alt={alt} 
+        className="inline rounded-lg max-w-full h-auto"
+        {...props} 
+      />
+    ),
+
     video: ({ node, ...props }: any) => {
       if (!node?.children) return null;
       


### PR DESCRIPTION
By leaving this component out, we were inheriting some Tailwind rules that made all images render as blocks, which kinda screwed up the flow of some pages where they were meant to render inline (e.g., two small images side by side, some images reflecting icons mid-paragraph, etc).