### PR TITLE
Fixes two bugs in changelogs

### DIFF
--- a/components/changelogs/ChangeLogEntry.js
+++ b/components/changelogs/ChangeLogEntry.js
@@ -13,7 +13,15 @@ const HEADER_HEIGHT = 80;
 
 export default function ChangeLogEntry({ item, index }) {
 
-  const releaseNotes = item?.releaseNotes;
+  // Replace Velocity template variables with actual values
+  const processReleaseNotes = (notes, version) => {
+    if (!notes) return notes;
+    
+    // Replace $!{version} with the actual version number
+    return notes.replace(/\$!?\{version\}/g, version || '');
+  };
+
+  const releaseNotes = processReleaseNotes(item?.releaseNotes, item?.minor);
   const useMarkdown = isMarkdownStrict(releaseNotes,2)
 
   const [copied, setCopied] = useState(false);
@@ -39,16 +47,17 @@ export default function ChangeLogEntry({ item, index }) {
           Available: {extractDateForTables(item?.releasedDate)}
         </div>
         <div className="text-sm text-muted-foreground">
-
+          {item?.dockerImage ? (
             <div className="flex items-center whitespace-nowrap min-w-0">
-              <span className="flex-shrink-0">docker tag : {item?.dockerImage.split(':')[1]}</span>
+              <span className="flex-shrink-0">docker tag : {item.dockerImage.split(':')[1]}</span>
               <button
                 onClick={() => {
-                  navigator.clipboard.writeText(item?.dockerImage);
+                  navigator.clipboard.writeText(item.dockerImage);
                   setCopied(true);
                   setTimeout(() => setCopied(false), 2000);
                 }}
                 className="inline-flex items-center ml-1 p-1 hover:bg-gray-100 rounded-md"
+                title="Copy docker image"
               >
                 {copied ? (
                   <Check className="w-4 h-4 text-green-500" />
@@ -56,14 +65,12 @@ export default function ChangeLogEntry({ item, index }) {
                   <Copy className="w-4 h-4" />
                 )}
               </button>
-
-              <div className="flex items-center whitespace-nowrap min-w-0 gap-2">
-
             </div>
-
-
+          ) : (
+            <div className="flex items-center whitespace-nowrap min-w-0">
+              <span className="flex-shrink-0 text-muted-foreground/60">docker tag : N/A</span>
             </div>
-
+          )}
         </div>
       </div>
 

--- a/components/releases/TableReleases/TableReleases.tsx
+++ b/components/releases/TableReleases/TableReleases.tsx
@@ -136,13 +136,14 @@ export const TableReleases: FC<{
                         onClick={() => { DockerComposeYAML({ 
                           version: release.minor, 
                           lts: release.lts !== "3", 
-                          dockerTag: release.dockerImage.replace("dotcms/dotcms:", ""), 
+                          dockerTag: release.dockerImage?.replace("dotcms/dotcms:", "") || release.minor, 
                           cleanStarter: release.starterEmpty, 
                           demoStarter: release.starter, 
                           includeDemo: false 
                         })}}
                         className="px-1 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 w-0 grow
                                   rounded-md transition-colors bg-indigo-100 dark:bg-indigo-600"
+                        disabled={!release.dockerImage}
                       >
                         Clean
                       </button>
@@ -150,13 +151,14 @@ export const TableReleases: FC<{
                         onClick={() => { DockerComposeYAML({ 
                             version: release.minor, 
                             lts: release.lts !== "3", 
-                            dockerTag: release.dockerImage.replace("dotcms/dotcms:", ""), 
+                            dockerTag: release.dockerImage?.replace("dotcms/dotcms:", "") || release.minor, 
                             cleanStarter: release.starterEmpty, 
                             demoStarter: release.starter, 
                             includeDemo: true 
                           })}}
                         className="px-1 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 w-0 grow
                                   rounded-md transition-colors bg-purple-100 dark:bg-purple-600"
+                        disabled={!release.dockerImage}
                       >
                         Demo Site
                       </button>


### PR DESCRIPTION
## Bug 1: Docker Image Nullability breaking old (like 6+ pages deep) changelog retrieval.

When you go too far back in the changelogs, you'd hit a graphQL error because of the non-nullability of the dockerImage field. I made it non-required, but that didn't seem to fix it. It's possible that I just didn't see it take effect due to a cache. Nevertheless, I've added some error handling that makes for a more graceful old-changelog browsing experience.

## Bug 2: Old Velocity cruft

Versions prior to 22 were full of old $!{version} Velocity vars. These are now properly filtered on retrieval.