### PR TITLE
adjusting PHP SDK slug

### DIFF
--- a/config/github-docs.ts
+++ b/config/github-docs.ts
@@ -58,7 +58,7 @@ export const GITHUB_DOCS_MAP: Record<string, GitHubConfig> = {
     path: 'core-web/libs/sdk/uve/README.md',
     branch: 'main'
   },
-  'php-sdk': {
+  'sdk-php-library': {
     owner: 'dotCMS',
     repo: 'dotcms-php-sdk',
     path: 'README.md',


### PR DESCRIPTION
I had pre-loaded a slug for a potential PHP SDK library page, but this just brings it into alignment with the others.