### PR TITLE
Swagger redirect points to demo (phase 1)

### DIFF
--- a/components/playgrounds/SwaggerUIComponent/SwaggerUIComponent.tsx
+++ b/components/playgrounds/SwaggerUIComponent/SwaggerUIComponent.tsx
@@ -3,7 +3,7 @@ import { type FC, useState, useEffect } from 'react'
 import SwaggerUI from 'swagger-ui-react'
 import { getOpenAPISpec } from '@/services/openapi/getOpenAPISpec'
 import type { OpenAPISpec } from '@/services/openapi/getOpenAPISpec'
-import { Config } from '@/util/config'
+import { createSwaggerRequestInterceptor } from '@/util/swaggerRequestInterceptor'
 
 import 'swagger-ui-react/swagger-ui.css'
 
@@ -30,29 +30,7 @@ const SwaggerUIComponent: FC = () => {
   }, []);
 
   // Request interceptor to add authentication headers and rewrite URLs
-  const requestInterceptor = (req: any) => {
-    // Don't modify requests that are loading the spec itself
-    if (req.loadSpec) {
-      return req;
-    }
-
-    // Rewrite API URLs to point to the backend server
-    const currentOrigin = window.location.origin;
-    if (req.url.startsWith(currentOrigin + '/api/')) {
-      // Replace frontend origin with backend origin
-      req.url = req.url.replace(currentOrigin, Config.DotCMSHost);
-    } else if (req.url.startsWith('/api/')) {
-      // Handle relative URLs
-      req.url = Config.DotCMSHost + req.url;
-    }
-
-    // Add authorization header
-    if (Config.AuthToken) {
-      req.headers.Authorization = `Bearer ${Config.AuthToken}`;
-    }
-
-    return req;
-  };
+  const requestInterceptor = createSwaggerRequestInterceptor();
 
   if (loading) {
     return (

--- a/util/config.ts
+++ b/util/config.ts
@@ -14,7 +14,8 @@ export const Config = {
   CDNHost: normalizedCDNHost as string,
   GraphqlUrl: process.env.NEXT_PUBLIC_API_GRAPH_URL || ((normalizedDotCMSHost + '/api/v1/graphql') as string),
   AuthToken: process.env.NEXT_PUBLIC_DOTCMS_AUTH_TOKEN as string,
-  SwaggerUrl: process.env.NEXT_PUBLIC_API_SWAGGER_URL || ((normalizedDotCMSHost + '/api/openapi.json') as string),
+  //SwaggerUrl: ((process.env.NEXT_PUBLIC_API_SWAGGER_URL || normalizedDotCMSHost) + '/api/openapi.json') as string,
+  SwaggerUrl: 'https://demo.dotcms.com/api/openapi.json',
   LogRequestEnabled: true,
   LanguageId: 1 as number,
   Headers: {

--- a/util/swaggerRequestInterceptor.ts
+++ b/util/swaggerRequestInterceptor.ts
@@ -10,8 +10,13 @@ const getBaseUrlFromSwaggerUrl = (swaggerUrl: string): string => {
     return `${url.protocol}//${url.host}`;
   } catch (error) {
     console.error('Invalid SwaggerUrl format:', swaggerUrl, error);
-    // Fallback to the original value if URL parsing fails
-    return swaggerUrl;
+    // Fallback: try to extract base URL manually using string manipulation
+    const match = swaggerUrl.match(/^(https?:\/\/[^\/]+)/);
+    if (match) {
+      return match[1];
+    }
+    // Final fallback - assume it's already a base URL
+    return swaggerUrl.replace(/\/.*$/, '');
   }
 };
 

--- a/util/swaggerRequestInterceptor.ts
+++ b/util/swaggerRequestInterceptor.ts
@@ -1,0 +1,45 @@
+import { Config } from '@/util/config';
+
+/**
+ * Extracts the base URL from a full URL
+ * e.g., "https://api.example.com/openapi.json" -> "https://api.example.com"
+ */
+const getBaseUrlFromSwaggerUrl = (swaggerUrl: string): string => {
+  try {
+    const url = new URL(swaggerUrl);
+    return `${url.protocol}//${url.host}`;
+  } catch (error) {
+    console.error('Invalid SwaggerUrl format:', swaggerUrl, error);
+    // Fallback to the original value if URL parsing fails
+    return swaggerUrl;
+  }
+};
+
+/**
+ * Shared request interceptor for SwaggerUI components
+ * Redirects API calls to the backend server and adds authentication
+ */
+export const createSwaggerRequestInterceptor = () => {
+  const backendBaseUrl = getBaseUrlFromSwaggerUrl(Config.SwaggerUrl);
+  
+  return (req: any) => {
+    // Don't modify requests that are loading the spec itself
+    if (req.loadSpec) {
+      return req;
+    }
+
+    // Rewrite API URLs to point to the backend server
+    const currentOrigin = window.location.origin;
+    if (req.url.startsWith(currentOrigin + '/api/')) {
+      // Replace frontend origin with backend origin
+      req.url = req.url.replace(currentOrigin, backendBaseUrl);
+    } else if (req.url.startsWith('/api/')) {
+      // Handle relative URLs
+      req.url = backendBaseUrl + req.url;
+    }
+
+    req.headers.Authorization = 'Basic YWRtaW5AZG90Y21zLmNvbTphZG1pbg==';
+
+    return req;
+  };
+};


### PR DESCRIPTION
Two changes:

1. Broke out the request interceptor from the two swagger components and gave it separate treatment that can then be imported into the two. (DRY)
2. Pointed Swagger URL provisionally (more on this in a second) toward demo.dotcms.com
3. Changed Swagger Auth to basic to suit Demo instance.

The "Provisional" pointing is, for the moment, a hard-coded string. I want to do this in multiple phases, since if I change the environment variable too soon there will be a short while where none of the endpoints will work. So the plan is:

1. Hard-code the string
2. Update the env
3. Replace hard-coded string with updated var.

So, there will be a much smaller "phase 2" merge after this one.