### PR TITLE
sub-sort by moddate after date

### DIFF
--- a/services/docs/getChangelog/getChangelog.ts
+++ b/services/docs/getChangelog/getChangelog.ts
@@ -94,7 +94,7 @@ export const getChangelog = async ({ page = 1, vLts = "false", singleVersion = "
   };
   const ltsMajVersion = sussOutLatestMajor(ltsMajorResult.DotcmsbuildsCollection[0], vLts);
   //console.log("sussed as:", ltsMajVersion);
-  const sortBy = 'Dotcmsbuilds.releasedDate desc';
+  const sortBy = 'Dotcmsbuilds.releasedDate desc, modDate desc';
   const query = assembleQuery(buildQuery, ltsQuery, ltsMajVersion, (singleVersion && !ltsPatchVersion) ? `+Dotcmsbuilds.minor:${singleVersion}` : "", (ltsMajVersion ? 20 : limit), page, sortBy);
   const result = await logRequest(async () => graphqlResults(query), 'getChangelog');
   


### PR DESCRIPTION
Added sorting by moddate after releaseddate, to help out when we have multiple releases in a day.

In the longer term, I'll probably want to look into adding a date/time field, setting it equal to the existing date field, and then finally removing the date field. But I'll need to think about how best to do that without causing a fuss. 

This is a fine stopgap.