### PR TITLE
adding mcp server page to GH doc fetch

### DIFF
--- a/config/github-docs.ts
+++ b/config/github-docs.ts
@@ -105,6 +105,12 @@ export const GITHUB_DOCS_MAP: Record<string, GitHubConfig> = {
     path: 'README.md',
     branch: 'main'
   },
+  'mcp-server': {
+    owner: 'dotCMS',
+    repo: 'core',
+    path: 'core-web/apps/mcp-server/README.md',
+    branch: 'main'
+  },
   // Add more SDK mappings as needed
 };
 


### PR DESCRIPTION
https://github.com/dotCMS/core/tree/main/core-web/apps/mcp-server

This will now be cloned onto a dotAI child page, ala the SDK libraries.