### PR TITLE
adds badge to title on "beta" tag

### DIFF
--- a/components/documentation/Documentation.js
+++ b/components/documentation/Documentation.js
@@ -6,6 +6,7 @@ import Breadcrumbs from "@/components/navigation/Breadcrumbs";
 import MarkdownContent from "@/components/MarkdownContent";
 import OnThisPage from "../navigation/OnThisPage";
 import Warn from "../mdx/Warn";
+import Info from "../mdx/Info";
 
 function cleanMarkdown(markdownString, identifierString) {
   return markdownString
@@ -41,7 +42,15 @@ const Documentation = ({ contentlet, sideNav, slug }) => {
           />
 
           <div className="markdown-content">
-            <h1 className="text-4xl font-bold mb-6">{contentlet.title}</h1>
+            <div className="flex items-center gap-3 mb-6">
+              <h1 className="text-4xl font-bold">{contentlet.title}</h1>
+              {contentlet.tag.includes("beta") && (
+                <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 border border-blue-200 shrink-0">
+                  <span className="w-2 h-2 bg-blue-400 rounded-full mr-2 animate-pulse"></span>
+                  Beta Feature
+                </span>
+              )}
+            </div>
             {contentlet.tag.includes("deprecated")  && (
               <div className="mb-6">
                 <Warn>

--- a/components/documentation/GitHubDocumentation.js
+++ b/components/documentation/GitHubDocumentation.js
@@ -114,7 +114,15 @@ const GitHubDocumentation = ({ contentlet, sideNav, slug }) => {
               </Alert>
             </div>
 
-            <h1 className="text-4xl font-bold mb-6">{contentlet.title}</h1>
+            <div className="flex items-center gap-3 mb-6">
+              <h1 className="text-4xl font-bold">{contentlet.title}</h1>
+              {contentlet.tag.includes("beta") && (
+                <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 border border-blue-200 shrink-0">
+                  <span className="w-2 h-2 bg-blue-400 rounded-full mr-2 animate-pulse"></span>
+                  Beta Feature
+                </span>
+              )}
+            </div>
             
             {contentlet.tag && contentlet.tag.includes("deprecated") && (
               <div className="mb-6">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nextjs",
       "version": "0.1.0",
       "dependencies": {
-        "@dotcms/analytics": "1.0.5-next.1",
+        "@dotcms/analytics": "^1.0.5-next.1",
         "@dotcms/client": "latest",
         "@dotcms/react": "latest",
         "@hookform/resolvers": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@dotcms/analytics": "1.0.5-next.1",
+    "@dotcms/analytics": "^1.0.5-next.1",
     "@dotcms/client": "latest",
     "@dotcms/react": "latest",
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
- Adds a simple badge to the titles of documents with a `beta` tag.
- Also updates package-lock.json to reflect new analytics stuff @oidacra added recently.