### PR TITLE
adding tags and seodescription to sidenav fetch

### DIFF
--- a/services/docs/getSideNav.ts
+++ b/services/docs/getSideNav.ts
@@ -19,36 +19,50 @@ export const getSideNav = async () => {
             navTitle
             urlTitle
             modDate
+            tag
+            seoDescription
             dotcmsdocumentationchildren {
                 title
                 navTitle
                 urlTitle
                 modDate
+                tag
+                seoDescription
                 dotcmsdocumentationchildren {
                     title
                     navTitle
                     urlTitle
                     modDate
+                    tag
+                    seoDescription
                     dotcmsdocumentationchildren {
                         title
                         navTitle
                         urlTitle
                         modDate
+                        tag
+                        seoDescription
                         dotcmsdocumentationchildren {
                             title
                             navTitle
                             urlTitle
                             modDate
+                            tag
+                            seoDescription
                             dotcmsdocumentationchildren {
                                 title
                                 navTitle
                                 urlTitle
                                 modDate
+                                tag
+                                seoDescription
                                 dotcmsdocumentationchildren {
                                     title
                                     navTitle
                                     urlTitle
                                     modDate
+                                    tag
+                                    seoDescription
                                 }
                             }
                         }


### PR DESCRIPTION
This is just laying some groundwork for the upcoming push. The new side-search will be referencing `tag` and `seoDescription` fields.

Probably should have moved this over the weekend, actually, so all the caches would be ready by now. Alas, hindsight.