### PR TITLE
adjusting error msg

### DIFF
--- a/components/releases/TableReleases/TableReleases.tsx
+++ b/components/releases/TableReleases/TableReleases.tsx
@@ -57,7 +57,7 @@ export const TableReleases: FC<{
   if (error) {
     return (
       <div className="flex items-center justify-center min-h-[400px] text-destructive">
-        Error loading changelogs: {error.message}
+        Error loading {downloadYAML ? "releases" : "changelogs"}: {error.message}
       </div>
     );
   }


### PR DESCRIPTION
Current Releases table won't say that you failed to load "changelogs" now, on error.