### PR TITLE
fixing block page asset styles (left nav, indent)

### DIFF
--- a/components/page-asset-with-content-block.js
+++ b/components/page-asset-with-content-block.js
@@ -39,7 +39,7 @@ export function BlockPageAsset({ pageAsset, nav, searchItems = [], serverPath })
         <div id="main-content" className="grid grid-cols-1 lg:grid-cols-[auto_1fr_auto] container mx-auto px-0 w-full">
           {/* Left Navigation - Hide on mobile */}
           {showLeftNav && (
-            <div id="left-nav" className="hidden lg:block w-72 h-[calc(100vh-4rem)] sticky top-16 overflow-y-auto">
+            <div id="left-nav" className="hidden lg:block w-72 shrink-0">
                 <RedesignedNavTree 
                   currentPath={pageAsset?.page?.url}
                   items={searchItems}
@@ -48,15 +48,17 @@ export function BlockPageAsset({ pageAsset, nav, searchItems = [], serverPath })
           )}
 
           {/* Main Content - Full width on mobile */}
-          <main id="content-here" className="min-w-0 px-4 pt-8 lg:px-8 [&_.container]:!p-0  border-l-2 border-gray-200">
-            <Breadcrumbs
-              items={Array.isArray(nav) ? nav : []}
-              slug={pageAsset.page.url}
-              childrenKey="children"
-              identifierKey="href"
-              basePath="/"
-            />
-            <h1 className="text-4xl font-bold mb-6">{pageAsset.page.title}</h1>
+          <main id="content-here" className="flex-1 min-w-0 py-8 lg:pb-12 px-0 sm:px-0 lg:px-8">
+            <div className="px-0 sm:px-0 lg:px-8">
+              <Breadcrumbs
+                items={Array.isArray(nav) ? nav : []}
+                slug={pageAsset.page.url}
+                childrenKey="children"
+                identifierKey="href"
+                basePath="/"
+              />
+              <h1 className="text-4xl font-bold mb-6">{pageAsset.page.title}</h1>
+            </div>
 
             {hasBlockContent && (
               <div className="prose dark:prose-invert mb-8">


### PR DESCRIPTION
A few styling changes to make the Getting Started section look more like the docs section:

- Left nav in the same position
- no line between nav and content
- correct indenting on content