### PR TITLE
nav REST API call handled server side w/cache

### DIFF
--- a/app/docs/[slug]/page.js
+++ b/app/docs/[slug]/page.js
@@ -13,6 +13,7 @@ import Documentation from "@/components/documentation/Documentation";
 import GitHubDocumentation from "@/components/documentation/GitHubDocumentation";
 import ChangeLogList from "@/components/changelogs/ChangeLogList";
 import RedesignedNavTree from "@/components/navigation/RedesignedNavTree";
+import { getNavSections } from "@/services/docs/getNavSections";
 import CurrentReleases from "@/components/releases/CurrentReleases";
 import AllReleases from "@/components/releases/AllReleases";
 import AllSecurityIssues from "@/components/security-issues/AllSecurityIssues";
@@ -246,6 +247,7 @@ export default async function Home({ searchParams, params }) {
     const path = "/docs/" + (slug || "table-of-contents");
     const hostname = "https://dev.dotcms.com";
     const { pageAsset, sideNav } = await fetchPageData(path, finalSearchParams, slug);
+    const navSections = await getNavSections({ path: '/docs/nav', depth: 4, languageId: 1, ttlSeconds: 600 });
     
     // NOTE: Vanity URL redirects are now handled by middleware
     // If we reach this point, it's not a vanity URL or the redirect already happened
@@ -284,7 +286,7 @@ export default async function Home({ searchParams, params }) {
 
     return (
         <div className="flex flex-col min-h-screen">
-            <Header sideNavItems={sideNav[0]?.dotcmsdocumentationchildren || []} currentPath={slug} />
+            <Header sideNavItems={sideNav[0]?.dotcmsdocumentationchildren || []} currentPath={slug} navSections={navSections} />
             <JsonLd pageData={data} path={path} hostname={hostname} />
             
             <div className="flex-1">
@@ -294,6 +296,7 @@ export default async function Home({ searchParams, params }) {
                         <RedesignedNavTree
                             currentPath={slug}
                             items={sideNav[0]?.dotcmsdocumentationchildren || []}
+                            initialSections={navSections}
                         />
                     </div>
 

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -27,14 +27,16 @@ import DiscourseLink from "./DiscourseLink";
 import GithubLink from "./GithubLink";
 import { SearchModal } from "../chat/SearchModal";
 import RedesignedNavTree from "@/components/navigation/RedesignedNavTree";
+import type { NavSection } from "@/util/navTransform";
 import LogoWithArrow from "./Logo/LogoWithArrow";
 
 type HeaderProps = {
   sideNavItems?: any[];
   currentPath?: string;
+  navSections?: NavSection[];
 };
 
-export default function Header({ sideNavItems, currentPath }: HeaderProps) {
+export default function Header({ sideNavItems, currentPath, navSections }: HeaderProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [showBackArrow, setShowBackArrow] = useState(false);
@@ -303,6 +305,7 @@ export default function Header({ sideNavItems, currentPath }: HeaderProps) {
                     currentPath={currentPath}
                     items={sideNavItems}
                     isMobile={true}
+                    initialSections={navSections}
                   />
                 </div>
               )}

--- a/services/docs/getNavSections.ts
+++ b/services/docs/getNavSections.ts
@@ -1,0 +1,50 @@
+import { Config } from "@/util/config";
+import { navCache, getCacheKey } from "@/util/cacheService";
+import { transformApiResponseToNavSections, type ApiNavItem, type NavSection } from "@/util/navTransform";
+
+type FetchOptions = {
+  path?: string;
+  depth?: number;
+  languageId?: number;
+  ttlSeconds?: number;
+};
+
+export async function getNavSections(options: FetchOptions = {}): Promise<NavSection[]> {
+  const path = options.path ?? '/docs/nav';
+  const depth = options.depth ?? 4;
+  const languageId = options.languageId ?? 1;
+  const ttlSeconds = options.ttlSeconds ?? 900;
+
+  const cacheKey = getCacheKey(`${path}|${depth}|${languageId}|v2`);
+  const cached = navCache.get<NavSection[]>(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const url = new URL(`/api/v1/nav${path}?depth=${depth}&languageId=${languageId}`, Config.DotCMSHost);
+
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: Config.Headers,
+    // Ensure server-side request cache doesn't interfere; we manage our own cache
+    cache: 'no-store',
+    next: { revalidate: 0 },
+  });
+
+  if (!res.ok) {
+    console.warn('Failed to fetch nav sections', res.status, res.statusText);
+    return [];
+  }
+
+  const json = await res.json();
+  const apiChildren: ApiNavItem[] = json?.entity?.children ?? [];
+  const sections = transformApiResponseToNavSections(apiChildren);
+
+  if (sections.length > 0) {
+    navCache.set(cacheKey, sections, ttlSeconds);
+  }
+
+  return sections;
+}
+
+

--- a/util/navTransform.ts
+++ b/util/navTransform.ts
@@ -1,0 +1,99 @@
+// Navigation transform utilities shared between server and client
+
+export interface NavItem {
+  title: string;
+  href: string;
+  icon?: any;
+  target?: string;
+  items?: NavItem[];
+}
+
+export interface NavSection {
+  title: string;
+  items: NavItem[];
+}
+
+export interface ApiNavItem {
+  type: 'folder' | 'link' | 'page';
+  title: string;
+  href?: string;
+  code?: string | null;
+  folder?: string;
+  order: number;
+  target?: string;
+  children: ApiNavItem[];
+}
+
+export function processLinkHref(linkData: ApiNavItem): string {
+  if (linkData.code && linkData.code.trim() !== '') {
+    return `/docs/${linkData.code}`;
+  }
+
+  if (linkData.href) {
+    if (linkData.href.startsWith('https://')) {
+      return linkData.href;
+    }
+
+    try {
+      const url = new URL(linkData.href);
+      return url.pathname + url.search + url.hash;
+    } catch (_e) {
+      return linkData.href;
+    }
+  }
+
+  return '#';
+}
+
+export function transformApiItemsToNavItems(items: ApiNavItem[]): NavItem[] {
+  if (!items || !Array.isArray(items)) {
+    return [];
+  }
+
+  return items
+    .sort((a, b) => a.order - b.order)
+    .map((item) => {
+      if (item.type === 'folder') {
+        const navItem: NavItem = {
+          title: item.title,
+          href: '#',
+        };
+
+        if (item.children && item.children.length > 0) {
+          navItem.items = transformApiItemsToNavItems(item.children);
+        }
+        return navItem;
+      } else if (item.type === 'link' || item.type === 'page') {
+        const navItem: NavItem = {
+          title: item.title,
+          href: processLinkHref(item),
+        };
+        if (item.target === '_blank') {
+          navItem.target = '_blank';
+        }
+        return navItem;
+      }
+
+      return {
+        title: item.title,
+        href: '#',
+      };
+    })
+    .filter(Boolean);
+}
+
+export function transformApiResponseToNavSections(apiData: ApiNavItem[]): NavSection[] {
+  if (!apiData || !Array.isArray(apiData)) {
+    return [];
+  }
+
+  return apiData
+    .filter((item) => item.type === 'folder')
+    .sort((a, b) => a.order - b.order)
+    .map((section) => ({
+      title: section.title,
+      items: transformApiItemsToNavItems(section.children || []),
+    }));
+}
+
+

--- a/util/page.utils.js
+++ b/util/page.utils.js
@@ -19,7 +19,7 @@ export const fetchPageData = async (params) => {
 };
 
 export const fetchNavData = async (dataIn) => {
-    const cacheTTL = dataIn.ttl || 600;
+    const cacheTTL = dataIn.ttl || 900;
     const cacheKey = getCacheKey(dataIn.path + dataIn.depth + dataIn.languageId);
 
     const cachedData = navCache.get(cacheKey);


### PR DESCRIPTION
Updated nav component to perform its Nav API call server side and pass cached responses, only using client-side fetch as a fallback.

Summary:

- Shared server-safe transformer in util:
  - Added util/navTransform.ts to share transformations on both server and client.
  - Added services/docs/getNavSections.ts to fetch and cache nav data on the server using your existing NodeCache (navCache). It returns already-transformed sections.
- Client component accepts server-provided data
  - Updated components/navigation/RedesignedNavTree.tsx to accept a new prop initialSections. If provided, it skips the client fetch and renders immediately. It still supports client fetch as a fallback for other contexts.
- Wiring into pages and header
  - app/docs/[slug]/page.js now calls getNavSections(...) server-side and passes navSections into both Header and the left-side RedesignedNavTree via initialSections.
  - components/header/header.tsx now accepts navSections and passes initialSections={navSections} to RedesignedNavTree in mobile view.

Pattern usable elsewhere:
- In any server component or route, call getNavSections({ path: '/docs/nav', depth: 4, languageId: 1 }) and pass the result as initialSections to RedesignedNavTree.
- The client component will render immediately with the server-cached data and avoid client-side fetching.