### PR TITLE
long nav items stay flush left

### DIFF
--- a/components/navigation/RedesignedNavTree.tsx
+++ b/components/navigation/RedesignedNavTree.tsx
@@ -577,7 +577,7 @@ const RedesignedNavTree: React.FC<RedesignedNavTreeProps> = ({
             onClick={handleToggleItem}
             type="button"
           >
-            <span className="flex items-center gap-2">
+            <span className="flex-1 min-w-0 text-left whitespace-normal break-words leading-snug">
               {item.title}
             </span>
             {isOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
@@ -605,7 +605,7 @@ const RedesignedNavTree: React.FC<RedesignedNavTreeProps> = ({
         )}
         style={{ paddingLeft }}
       >
-        {item.title}
+        <span className="block text-left whitespace-normal break-words leading-snug">{item.title}</span>
       </Link>
     );
   }, [openSections, toggleSection, isCurrentPage, isParentActive]);
@@ -635,7 +635,7 @@ const RedesignedNavTree: React.FC<RedesignedNavTreeProps> = ({
           onClick={handleToggle}
           type="button"
         >
-          <span>{section.title}</span>
+          <span className="flex-1 min-w-0 text-left whitespace-normal break-words leading-snug">{section.title}</span>
           {isOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
         </button>
         


### PR DESCRIPTION
Long nav item names were screwing up EVERYTHING!

<img width="282" height="165" alt="image" src="https://github.com/user-attachments/assets/fe947290-cad0-4151-b1d7-7a4c5a198f37" />

You maniac!

So we fix:

<img width="288" height="135" alt="image" src="https://github.com/user-attachments/assets/46ecaf8f-1555-4a93-b228-a251409b1612" />

Much better.