### PR TITLE
changed talentlms link

### DIFF
--- a/components/learning/devresource-grid.tsx
+++ b/components/learning/devresource-grid.tsx
@@ -56,7 +56,7 @@ export function DevResourceGrid(count: any) {
         />
 
         <FeatureCard
-          href={`https://dotcms.talentlms.com/plus/login`}
+          href={`https://dotcms.talentlms.com/catalog/index`}
           icon={GraduationCap}
           title={"Training & Courses "}
           description={"Learn dotCMS with our training courses. "}


### PR DESCRIPTION
This just changes this:

- https://dotcms.talentlms.com/plus/login

to this:

- https://dotcms.talentlms.com/catalog/index

on this page:

- https://dev.dotcms.com/learning