### PR TITLE
Fixed the URLs to allow `-` characters to be used in the course slugs…

### DIFF
--- a/app/api/sitemap/route.js
+++ b/app/api/sitemap/route.js
@@ -2,6 +2,9 @@ import { getSideNav } from "@/services/docs/getSideNav";
 import { Config } from "@/util/config";
 import { getBlogListing } from "@/services/blog/getBlogListing";
 import { getDevResources } from "@/services/learning/getDevResources";
+
+/** Aggregates many GraphQL calls; never freeze this into a static build artifact. */
+export const dynamic = "force-dynamic";
 const extractHrefs = (obj) => {
   const baseURL = `${Config.CDNHost}/docs/`;
   let hrefs = [];

--- a/app/docs/authoring/page.tsx
+++ b/app/docs/authoring/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { PersonaLandingPage } from "@/components/persona-landing/PersonaLandingPage";
 
+/** CMS nav is fetched at request time so a slow or unavailable GraphQL during `next build` does not fail the deploy. */
+export const dynamic = "force-dynamic";
+
 const hostname = "https://dev.dotcms.com";
 
 export const metadata: Metadata = {

--- a/app/docs/developer/page.tsx
+++ b/app/docs/developer/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { PersonaLandingPage } from "@/components/persona-landing/PersonaLandingPage";
 
+/** CMS nav is fetched at request time so a slow or unavailable GraphQL during `next build` does not fail the deploy. */
+export const dynamic = "force-dynamic";
+
 const hostname = "https://dev.dotcms.com";
 
 export const metadata: Metadata = {

--- a/app/docs/devops/page.tsx
+++ b/app/docs/devops/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { PersonaLandingPage } from "@/components/persona-landing/PersonaLandingPage";
 
+/** CMS nav is fetched at request time so a slow or unavailable GraphQL during `next build` does not fail the deploy. */
+export const dynamic = "force-dynamic";
+
 const hostname = "https://dev.dotcms.com";
 
 export const metadata: Metadata = {

--- a/app/learn/[slug]/[chapter]/page.js
+++ b/app/learn/[slug]/[chapter]/page.js
@@ -1,7 +1,31 @@
-import { getCourseDetail } from "@/services/courses/getCourse";
+import { courseTitleForMetadata, getCourseDetail } from "@/services/courses/getCourse";
 import MarkdownContent from "@/components/MarkdownContent";
 import { notFound } from "next/navigation";
 import ChapterFooter from "../ChapterFooter";
+
+export async function generateMetadata({ params }) {
+  const { slug, chapter } = await params;
+  const { course } = await getCourseDetail({ slug });
+  if (!course) {
+    return { title: "Course not found" };
+  }
+
+  const match = chapter.match(/^chapter-(\d+)$/);
+  if (!match) {
+    return { title: "Chapter not found" };
+  }
+
+  const index = parseInt(match[1], 10) - 1;
+  const chapterData = course.chapters[index];
+  if (!chapterData) {
+    return { title: "Chapter not found" };
+  }
+
+  const total = course.chapters?.length ?? 0;
+  const n = index + 1;
+  const label = courseTitleForMetadata(course);
+  return { title: `${label} · Ch. ${n}/${total} — ${chapterData.title}` };
+}
 
 export default async function ChapterPage({ params }) {
   const { slug, chapter } = await params;

--- a/app/learn/[slug]/page.js
+++ b/app/learn/[slug]/page.js
@@ -1,7 +1,16 @@
-import { getCourseDetail } from "@/services/courses/getCourse";
+import { courseTitleForMetadata, getCourseDetail } from "@/services/courses/getCourse";
 import ChapterFooter from "./ChapterFooter";
 import CourseIntroduction from "./CourseIntroduction";
 import { notFound } from "next/navigation";
+
+export async function generateMetadata({ params }) {
+  const { slug } = await params;
+  const { course } = await getCourseDetail({ slug });
+  if (!course) {
+    return { title: "Course not found" };
+  }
+  return { title: courseTitleForMetadata(course) };
+}
 
 export default async function CoursePage({ params }) {
   const { slug } = await params;

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Code2, Menu, Search, X, ArrowLeft, ExternalLink } from "lucide-react";
+import { Code2, Menu, Search, X, ExternalLink } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
 import {
   NavigationMenu,
@@ -11,14 +11,6 @@ import {
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
-import {
-  Sheet,
-  SheetContent,
-  SheetTrigger,
-  SheetClose,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
 import Link from "next/link";
 import * as React from "react";
 import { cn } from "@/util/utils";
@@ -37,16 +29,250 @@ type HeaderProps = {
   navSections?: NavSection[];
 };
 
+const GETTING_STARTED_NAV_ITEM_VALUE = "getting-started-nav";
+const ACTIVITY_FEEDS_NAV_ITEM_VALUE = "activity-feeds-nav";
+
+type HeaderDesktopNavMenuProps = {
+  currentOpenMenu: string | undefined;
+  setCurrentOpenMenu: React.Dispatch<React.SetStateAction<string | undefined>>;
+};
+
+/** Module-level component so Radix useId order matches between SSR and hydration (avoid defining components inside Header). */
+function HeaderDesktopNavMenu({ currentOpenMenu, setCurrentOpenMenu }: HeaderDesktopNavMenuProps) {
+  return (
+    <NavigationMenu
+      value={currentOpenMenu}
+      onValueChange={(newValue) => {
+        if (
+          newValue === GETTING_STARTED_NAV_ITEM_VALUE ||
+          newValue === ACTIVITY_FEEDS_NAV_ITEM_VALUE
+        ) {
+          return;
+        }
+        setCurrentOpenMenu(newValue);
+      }}
+      delayDuration={300 * 1000}
+    >
+      <NavigationMenuList className="space-x-1">
+        <NavigationMenuItem value={GETTING_STARTED_NAV_ITEM_VALUE} className="relative">
+          <NavigationMenuTrigger
+            className="px-3"
+            onClick={(e) => {
+              e.preventDefault();
+              if (currentOpenMenu === GETTING_STARTED_NAV_ITEM_VALUE) {
+                setCurrentOpenMenu(undefined);
+              } else {
+                setCurrentOpenMenu(GETTING_STARTED_NAV_ITEM_VALUE);
+              }
+            }}
+          >
+            Getting Started
+          </NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
+              <li className="row-span-3">
+                <NavigationMenuLink asChild>
+                  <a
+                    className="flex h-full w-full select-none flex-col  rounded-md bg-gradient-to-b from-muted/50 to-muted p-6 no-underline outline-none focus:shadow-md"
+                    href="/getting-started"
+                  >
+                    <div className="mb-2 mt-4 text-lg font-medium">
+                      dotDev <Code2 className="h-6 w-6 inline-block" />
+                    </div>
+                    <p className="text-sm leading-tight text-muted-foreground">
+                      Your one-stop site for learning dotCMS, including Docs, resources and tools.
+                    </p>
+                  </a>
+                </NavigationMenuLink>
+              </li>
+              <ListItem href="/getting-started" title="Introduction">
+                Learn about dotCMS&apos;s core concepts and architecture.
+              </ListItem>
+              <ListItem href="/docs/quick-start-guide" title="Headless Quick Start">
+                Get up and running in less than 5 minutes.
+              </ListItem>
+              <ListItem href="/docs/features" title="Features">
+                Explore our comprehensive feature set.
+              </ListItem>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink asChild>
+            <Link href="/docs/table-of-contents?n=0">
+              <span className={cn(navigationMenuTriggerStyle(), "px-3")}>Docs</span>
+            </Link>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink asChild>
+            <Link href="/learning">
+              <span className={cn(navigationMenuTriggerStyle(), "px-3")}>Learning & Blogs</span>
+            </Link>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        <NavigationMenuItem value={ACTIVITY_FEEDS_NAV_ITEM_VALUE} className="relative">
+          <NavigationMenuTrigger
+            className="px-3"
+            onClick={(e) => {
+              e.preventDefault();
+              if (currentOpenMenu === ACTIVITY_FEEDS_NAV_ITEM_VALUE) {
+                setCurrentOpenMenu(undefined);
+              } else {
+                setCurrentOpenMenu(ACTIVITY_FEEDS_NAV_ITEM_VALUE);
+              }
+            }}
+          >
+            Activity Feeds
+          </NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid w-[360px] gap-3 p-4 sm:w-[400px] md:w-[520px] md:grid-cols-2">
+              <ListItem href="/docs/changelogs" title="Changelogs">
+                Release notes and version history.
+              </ListItem>
+              <ListItem href="/docs/known-security-issues" title="Known security issues">
+                Advisories and security-related updates.
+              </ListItem>
+              <ListItem href="/docs/upgrading-important-changes" title="Important / breaking changes">
+                Must-read notes before you upgrade.
+              </ListItem>
+              <ListItem href="/docs/deprecations" title="Deprecations">
+                Features, APIs, and other components slated for removal.
+              </ListItem>
+              <ListItem href="/docs/current-releases" title="Current Releases">
+                Supported versions and what is shipping now.
+              </ListItem>
+              <ListItem href="/docs/all-releases" title="All Releases">
+                Full list of dotCMS releases.
+              </ListItem>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink asChild>
+            <a
+              href="https://community.dotcms.com/"
+              target="dotCMSCommunity"
+              className={navigationMenuTriggerStyle()}
+            >
+              Community <ExternalLink className="h-3 w-3 inline-block ml-1" />
+            </a>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  );
+}
+
+function HeaderMobileNavLinks() {
+  return (
+    <nav className="flex flex-col space-y-4">
+      <div className="space-y-1">
+        <Link
+          prefetch={false}
+          href="/getting-started"
+          className={cn(navigationMenuTriggerStyle(), "w-full justify-start h-9 px-4")}
+        >
+          Getting Started
+        </Link>
+
+        <Link
+          prefetch={false}
+          href="/docs/table-of-contents?n=0"
+          className={cn(navigationMenuTriggerStyle(), "w-full justify-start h-9 px-4")}
+        >
+          Docs
+        </Link>
+
+        <Link
+          prefetch={false}
+          href="/learning"
+          className={cn(navigationMenuTriggerStyle(), "w-full justify-start h-9 px-4")}
+        >
+          Learning & Blogs
+        </Link>
+
+        <div className="space-y-1 border-l-2 border-border pl-3 ml-1">
+          <p className="px-4 pt-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Activity Feeds</p>
+          <Link
+            prefetch={false}
+            href="/docs/changelogs"
+            className={cn(navigationMenuTriggerStyle(), "w-full justify-start h-9 px-4")}
+          >
+            Changelogs
+          </Link>
+          <Link
+            prefetch={false}
+            href="/docs/known-security-issues"
+            className={cn(navigationMenuTriggerStyle(), "w-full justify-start h-9 px-4")}
+          >
+            Known security issues
+          </Link>
+          <Link
+            prefetch={false}
+            href="/docs/upgrading-important-changes"
+            className={cn(navigationMenuTriggerStyle(), "w-full justify-start h-9 px-4")}
+          >
+            Important / breaking changes
+          </Link>
+          <Link
+            prefetch={false}
+            href="/docs/deprecations"
+            className={cn(navigationMenuTriggerStyle(), "w-full justify-start h-9 px-4")}
+          >
+            Deprecations
+          </Link>
+          <Link
+            prefetch={false}
+            href="/docs/current-releases"
+            className={cn(navigationMenuTriggerStyle(), "w-full justify-start h-9 px-4")}
+          >
+            Current Releases
+          </Link>
+          <Link
+            prefetch={false}
+            href="/docs/all-releases"
+            className={cn(navigationMenuTriggerStyle(), "w-full justify-start h-9 px-4")}
+          >
+            All Releases
+          </Link>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+const ListItem = React.forwardRef<
+  React.ElementRef<"a">,
+  React.ComponentPropsWithoutRef<"a">
+>(({ className, title, children, ...props }, ref) => {
+  return (
+    <li>
+      <NavigationMenuLink asChild>
+        <a
+          ref={ref}
+          className={cn(
+            "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
+            className
+          )}
+          {...props}
+        >
+          <div className="text-sm font-medium leading-none">{title}</div>
+          <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">{children}</p>
+        </a>
+      </NavigationMenuLink>
+    </li>
+  );
+});
+ListItem.displayName = "ListItem";
+
 export default function Header({ sideNavItems, currentPath, navSections }: HeaderProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [showBackArrow, setShowBackArrow] = useState(false);
   const [hoverTimeout, setHoverTimeout] = useState<NodeJS.Timeout | null>(null);
 
-  // State for controlled navigation menu
   const [currentOpenMenu, setCurrentOpenMenu] = useState<string | undefined>(undefined);
-  const GETTING_STARTED_NAV_ITEM_VALUE = "getting-started-nav";
-  const ACTIVITY_FEEDS_NAV_ITEM_VALUE = "activity-feeds-nav";
 
   const handleLogoMouseEnter = () => {
     if (hoverTimeout) {
@@ -103,259 +329,6 @@ export default function Header({ sideNavItems, currentPath, navSections }: Heade
     };
   }, [isMobileMenuOpen]);
 
-  const MobileNavItems = () => {
-    return (
-      <nav className="flex flex-col space-y-4">
-        <div className="space-y-1">
-          <Link
-            prefetch={false}
-            href="/getting-started"
-            className={cn(
-              navigationMenuTriggerStyle(),
-              "w-full justify-start h-9 px-4"
-            )}
-          >
-            Getting Started
-          </Link>
-
-          <Link
-            prefetch={false}
-            href="/docs/table-of-contents?n=0"
-            className={cn(
-              navigationMenuTriggerStyle(),
-              "w-full justify-start h-9 px-4"
-            )}
-          >
-            Docs
-          </Link>
-
-          <Link
-            prefetch={false}
-            href="/learning"
-            className={cn(
-              navigationMenuTriggerStyle(),
-              "w-full justify-start h-9 px-4"
-            )}
-          >
-            Learning & Blogs
-          </Link>
-
-          <div className="space-y-1 border-l-2 border-border pl-3 ml-1">
-            <p className="px-4 pt-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Activity Feeds
-            </p>
-            <Link
-              prefetch={false}
-              href="/docs/changelogs"
-              className={cn(
-                navigationMenuTriggerStyle(),
-                "w-full justify-start h-9 px-4"
-              )}
-            >
-              Changelogs
-            </Link>
-            <Link
-              prefetch={false}
-              href="/docs/known-security-issues"
-              className={cn(
-                navigationMenuTriggerStyle(),
-                "w-full justify-start h-9 px-4"
-              )}
-            >
-              Known security issues
-            </Link>
-            <Link
-              prefetch={false}
-              href="/docs/upgrading-important-changes"
-              className={cn(
-                navigationMenuTriggerStyle(),
-                "w-full justify-start h-9 px-4"
-              )}
-            >
-              Important / breaking changes
-            </Link>
-            <Link
-              prefetch={false}
-              href="/docs/deprecations"
-              className={cn(
-                navigationMenuTriggerStyle(),
-                "w-full justify-start h-9 px-4"
-              )}
-            >
-              Deprecations
-            </Link>
-            <Link
-              prefetch={false}
-              href="/docs/current-releases"
-              className={cn(
-                navigationMenuTriggerStyle(),
-                "w-full justify-start h-9 px-4"
-              )}
-            >
-              Current Releases
-            </Link>
-            <Link
-              prefetch={false}
-              href="/docs/all-releases"
-              className={cn(
-                navigationMenuTriggerStyle(),
-                "w-full justify-start h-9 px-4"
-              )}
-            >
-              All Releases
-            </Link>
-          </div>
-        </div>
-      </nav>
-    );
-  };
-
-  const NavItems = () => {
-    return (
-      <NavigationMenu
-        value={currentOpenMenu}
-        onValueChange={(newValue) => {
-          // If Radix tries to set these menus via onValueChange (e.g., due to hover/focus),
-          // we ignore because opening is controlled exclusively by onClick on each trigger.
-          if (
-            newValue === GETTING_STARTED_NAV_ITEM_VALUE ||
-            newValue === ACTIVITY_FEEDS_NAV_ITEM_VALUE
-          ) {
-            return;
-          }
-          // For any other menu item opening, or for *any* menu closing (newValue is undefined),
-          // update the state. This allows Radix to close "Getting Started" if it was opened by click.
-          setCurrentOpenMenu(newValue);
-        }}
-        delayDuration={300*1000} // Keep high delay as a fallback, primary logic is now in onValueChange
-      >
-        <NavigationMenuList className="space-x-1">
-          <NavigationMenuItem
-            value={GETTING_STARTED_NAV_ITEM_VALUE}
-            className="relative"
-          >
-            <NavigationMenuTrigger
-              className="px-3"
-              onClick={(e) => {
-                e.preventDefault(); // Prevent any default link behavior if it were a link
-                if (currentOpenMenu === GETTING_STARTED_NAV_ITEM_VALUE) {
-                  setCurrentOpenMenu(undefined); // Toggle close
-                } else {
-                  setCurrentOpenMenu(GETTING_STARTED_NAV_ITEM_VALUE); // Toggle open
-                }
-              }}
-            >
-              Getting Started
-            </NavigationMenuTrigger>
-            <NavigationMenuContent>
-              <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
-                <li className="row-span-3">
-                  <NavigationMenuLink asChild>
-                    <a
-                      className="flex h-full w-full select-none flex-col  rounded-md bg-gradient-to-b from-muted/50 to-muted p-6 no-underline outline-none focus:shadow-md"
-                      href="/getting-started"
-                    >
-                      <div className="mb-2 mt-4 text-lg font-medium">
-                        dotDev <Code2 className="h-6 w-6 inline-block" />
-                      </div>
-                      <p className="text-sm leading-tight text-muted-foreground">
-                        Your one-stop site for learning dotCMS, including Docs,
-                        resources and tools.
-                      </p>
-                    </a>
-                  </NavigationMenuLink>
-                </li>
-                <ListItem href="/getting-started" title="Introduction">
-                  Learn about dotCMS&apos;s core concepts and architecture.
-                </ListItem>
-                <ListItem
-                  href="/docs/quick-start-guide"
-                  title="Headless Quick Start"
-                >
-                  Get up and running in less than 5 minutes.
-                </ListItem>
-                <ListItem href="/docs/features" title="Features">
-                  Explore our comprehensive feature set.
-                </ListItem>
-              </ul>
-            </NavigationMenuContent>
-          </NavigationMenuItem>
-          <NavigationMenuItem>
-            <NavigationMenuLink asChild>
-              <Link href="/docs/table-of-contents?n=0">
-                <span className={cn(navigationMenuTriggerStyle(), "px-3")}>
-                  Docs
-                </span>
-              </Link>
-            </NavigationMenuLink>
-          </NavigationMenuItem>
-          <NavigationMenuItem>
-            <NavigationMenuLink asChild>
-              <Link href="/learning">
-                <span className={cn(navigationMenuTriggerStyle(), "px-3")}>
-                  Learning & Blogs
-                </span>
-              </Link>
-            </NavigationMenuLink>
-          </NavigationMenuItem>
-          <NavigationMenuItem
-            value={ACTIVITY_FEEDS_NAV_ITEM_VALUE}
-            className="relative"
-          >
-            <NavigationMenuTrigger
-              className="px-3"
-              onClick={(e) => {
-                e.preventDefault();
-                if (currentOpenMenu === ACTIVITY_FEEDS_NAV_ITEM_VALUE) {
-                  setCurrentOpenMenu(undefined);
-                } else {
-                  setCurrentOpenMenu(ACTIVITY_FEEDS_NAV_ITEM_VALUE);
-                }
-              }}
-            >
-              Activity Feeds
-            </NavigationMenuTrigger>
-            <NavigationMenuContent>
-              <ul className="grid w-[360px] gap-3 p-4 sm:w-[400px] md:w-[520px] md:grid-cols-2">
-                <ListItem href="/docs/changelogs" title="Changelogs">
-                  Release notes and version history.
-                </ListItem>
-                <ListItem
-                  href="/docs/known-security-issues"
-                  title="Known security issues"
-                >
-                  Advisories and security-related updates.
-                </ListItem>
-                <ListItem
-                  href="/docs/upgrading-important-changes"
-                  title="Important / breaking changes"
-                >
-                  Must-read notes before you upgrade.
-                </ListItem>
-                <ListItem href="/docs/deprecations" title="Deprecations">
-                  Features, APIs, and other components slated for removal.
-                </ListItem>
-                <ListItem href="/docs/current-releases" title="Current Releases">
-                  Supported versions and what is shipping now.
-                </ListItem>
-                <ListItem href="/docs/all-releases" title="All Releases">
-                  Full list of dotCMS releases.
-                </ListItem>
-              </ul>
-            </NavigationMenuContent>
-          </NavigationMenuItem>
-          <NavigationMenuItem>
-            <NavigationMenuLink asChild>
-              <a href="https://community.dotcms.com/" target="dotCMSCommunity" className={navigationMenuTriggerStyle()}>
-                Community <ExternalLink className="h-3 w-3 inline-block ml-1" />
-              </a>
-            </NavigationMenuLink>
-          </NavigationMenuItem>
-        </NavigationMenuList>
-      </NavigationMenu>
-    );
-  };
-
   return (
     <header className="sticky top-0 z-50 w-full">
       <div className="border-b bg-background">
@@ -363,7 +336,10 @@ export default function Header({ sideNavItems, currentPath, navSections }: Heade
           <LogoWithArrow />
           
           <div className="hidden lg:flex items-center space-x-2">
-            <NavItems />
+            <HeaderDesktopNavMenu
+              currentOpenMenu={currentOpenMenu}
+              setCurrentOpenMenu={setCurrentOpenMenu}
+            />
           </div>
 
           {/* Right side items */}
@@ -412,7 +388,7 @@ export default function Header({ sideNavItems, currentPath, navSections }: Heade
             <div className="flex flex-col h-full">
               {/* Main Navigation Links */}
               <div className="py-4">
-                <MobileNavItems />
+                <HeaderMobileNavLinks />
               </div>
 
               {/* Side Navigation Tree (if available) */}
@@ -450,29 +426,3 @@ export default function Header({ sideNavItems, currentPath, navSections }: Heade
     </header>
   );
 }
-
-const ListItem = React.forwardRef<
-  React.ElementRef<"a">,
-  React.ComponentPropsWithoutRef<"a">
->(({ className, title, children, ...props }, ref) => {
-  return (
-    <li>
-      <NavigationMenuLink asChild>
-        <a
-          ref={ref}
-          className={cn(
-            "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
-            className
-          )}
-          {...props}
-        >
-          <div className="text-sm font-medium leading-none">{title}</div>
-          <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-            {children}
-          </p>
-        </a>
-      </NavigationMenuLink>
-    </li>
-  );
-});
-ListItem.displayName = "ListItem";

--- a/services/courses/getCourse.js
+++ b/services/courses/getCourse.js
@@ -5,11 +5,28 @@ function escapeLuceneValue(value) {
   return String(value).replace(/([+\-!(){}[\]^"~*?:\\/])/g, "\\$1");
 }
 
+/** Backslashes and quotes must be escaped when embedding in a GraphQL "string" literal. */
+function escapeGraphqlStringLiteral(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/** Prefer optional CMS `shortTitle` for browser tab / metadata when set. */
+export function courseTitleForMetadata(course) {
+  const short = course?.shortTitle;
+  if (typeof short === "string" && short.trim()) return short.trim();
+  if (short && typeof short === "object" && typeof short.value === "string" && short.value.trim()) {
+    return short.value.trim();
+  }
+  return course?.title ?? "";
+}
+
 export async function getCourseDetail({ slug }) {
-  const safeSlug = escapeLuceneValue(slug);
+  const luceneSlug = escapeLuceneValue(slug);
+  const safeSlug = escapeGraphqlStringLiteral(luceneSlug);
   const query = `query ContentAPI {
   CourseE2eCollection(query: "+CourseE2e.urlTitle:${safeSlug}", limit: 1) {
     title,
+    shortTitle
     urlTitle
     introduction {
       json


### PR DESCRIPTION
…. I also added a `shortTitle` to the content type separately, so I had to crowbar it into the site code, too. Finally, the course page tabs will also display the course titles themselves (or shortTitle, if defined) along with a simple chapter reference ("Ch. 1/8").