### PR TITLE
Add Privacy Policy link to footer

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -58,6 +58,9 @@ export default function Footer() {
           <Link href="https://www.dotcms.com/contact-us" prefetch={false}   target="_blank" rel="noopener noreferrer" className="text-sm text-muted-foreground hover:text-foreground">
             Contact
           </Link>
+          <Link href="/docs/privacy-policy" className="text-sm text-muted-foreground hover:text-foreground">
+            Privacy Policy
+          </Link>
         </nav>
 
         <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Adds a Privacy Policy link to the global footer nav, pointing to `/docs/privacy-policy`
- Appears on every page since `Footer` is rendered in `app/layout.tsx`

## Test plan
- [ ] Verify the "Privacy Policy" link appears in the footer on the home page
- [ ] Verify it appears on doc/blog/learning/video pages
- [ ] Click the link and confirm it navigates to `/docs/privacy-policy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)