### PR TITLE
Add conversion tracking for search bar and AI chat

### DIFF
--- a/components/chat/ChatComponent.tsx
+++ b/components/chat/ChatComponent.tsx
@@ -19,13 +19,16 @@ import {
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { useContentAnalytics } from "@dotcms/analytics/react";
 import { cn } from "@/util/utils";
 import { CopyButton } from "@/components/chat/CopyButton";
-import { Config } from "@/util/config";
+import { AnalyticsConfig, Config } from "@/util/config";
 import {
   formatDocSourcePath,
   sourceHrefToDisplay,
 } from "@/components/chat/sourceLinks";
+
+const CONVERSION_EVENT = "ai-chat-question-sent";
 
 export type DocSource = {
   id: number;
@@ -317,6 +320,7 @@ export const ChatComponent = forwardRef<ChatComponentHandle, ChatComponentProps>
     const [currentStreamingMessage, setCurrentStreamingMessage] = useState("");
     const [recentQuestions, setRecentQuestions] = useState<string[]>([]);
     const abortControllerRef = useRef<AbortController | null>(null);
+    const { conversion } = useContentAnalytics(AnalyticsConfig);
 
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const formRef = useRef<HTMLFormElement>(null);
@@ -537,6 +541,7 @@ export const ChatComponent = forwardRef<ChatComponentHandle, ChatComponentProps>
       e.preventDefault();
       if (loading) return;
       if (!input.trim()) return;
+      conversion(CONVERSION_EVENT);
       storeRecentQuestion(input.trim());
       await sendMessage(e);
     }

--- a/components/header/DocsQuickSearch.tsx
+++ b/components/header/DocsQuickSearch.tsx
@@ -3,13 +3,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { Search, X } from "lucide-react";
+import { useContentAnalytics } from "@dotcms/analytics/react";
 import { cn } from "@/util/utils";
+import { AnalyticsConfig } from "@/util/config";
 import {
   flattenItems,
   performSearch,
   highlightMatch,
   type SearchResult,
 } from "@/util/docsSearch";
+
+const CONVERSION_EVENT = "search-bar-result-click";
 
 type DocsQuickSearchProps = {
   /** When set and non-empty, used directly (no extra request). */
@@ -24,6 +28,7 @@ export function DocsQuickSearch({ items: itemsProp, className }: DocsQuickSearch
   const [remoteItems, setRemoteItems] = useState<any[] | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const { conversion } = useContentAnalytics(AnalyticsConfig);
 
   const hasInlineTree = Array.isArray(itemsProp) && itemsProp.length > 0;
 
@@ -112,10 +117,11 @@ export function DocsQuickSearch({ items: itemsProp, className }: DocsQuickSearch
   }, []);
 
   const handleSuggestionSelect = useCallback(() => {
+    conversion(CONVERSION_EVENT);
     setSearchQuery("");
     setSearchResults([]);
     setPanelOpen(false);
-  }, []);
+  }, [conversion]);
 
   return (
     <div ref={rootRef} className={cn("relative min-w-0 flex-1 max-w-lg", className)}>


### PR DESCRIPTION
## Summary
- Fires `conversion("search-bar-result-click")` when a user clicks a result in the header search bar (`DocsQuickSearch.tsx`).
- Fires `conversion("ai-chat-question-sent")` when a user submits a question in the AI chat — covers both Enter and Send button via `handleSubmit` (`ChatComponent.tsx`).
- Event names extracted to a `CONVERSION_EVENT` constant at the top of each component.
- Reuses the existing `AnalyticsConfig` from `util/config.ts` and the `useContentAnalytics` hook from `@dotcms/analytics/react` already wired in `app/layout.tsx`.

## Notes
- Custom data is intentionally not sent yet — the BE does not currently process it. When that lands, we can pass the query/question as a second arg to `conversion()`.

## Test plan
- [ ] Open the site, type in the header search bar, click a result → verify `search-bar-result-click` conversion request fires in Network tab.
- [ ] Open the AI chat (Cmd+K / Cmd+/), type a question, press Enter → verify `ai-chat-question-sent` fires.
- [ ] Repeat with click on Send button → verify same event fires.
- [ ] Submit empty input or while a response is streaming → verify no event fires.
