### PR TITLE
Add Warmly script loader

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import MicrosoftClarity from '@/components/metrics/MicrosoftClarity';
 import { InitialScroll } from '@/components/InitialScroll';
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import { LeadboxerScript } from '@/components/metrics/Leadboxer';
+import { WarmlyScript } from '@/components/metrics/Warmly';
 import { DotContentAnalytics } from "@dotcms/analytics/react";
 import { AnalyticsConfig } from '@/util/config';
 import { AssistantProvider } from '@/components/chat/AssistantProvider';
@@ -95,6 +96,7 @@ export default function RootLayout({
         <GoogleAnalytics gaId="G-CM1HLQW35G" />
         <MicrosoftClarity />
         <LeadboxerScript />
+        <WarmlyScript />
         <SpeedInsights />
       </body>
     </html>

--- a/components/metrics/Warmly.js
+++ b/components/metrics/Warmly.js
@@ -1,0 +1,10 @@
+import Script from 'next/script';
+
+export function WarmlyScript() {
+    return (
+        <Script
+            id="warmly-script-loader"
+            src="https://opps-widget.getwarmly.com/warmly.js?clientId=4819f621f434715d064bd2650e7e8f24"
+            strategy="afterInteractive"></Script>
+    );
+}


### PR DESCRIPTION
## Summary
Adds the Warmly opps-widget script to the site.

- New `components/metrics/Warmly.js` — wraps the Warmly loader in a `next/script` `<Script>` component with `strategy="afterInteractive"` (idiomatic equivalent of the original `defer` tag).
- Wired `<WarmlyScript />` into `app/layout.tsx` alongside the other metrics scripts (Leadboxer, Clarity, GA).

## Script added
```html
<script id="warmly-script-loader" src="https://opps-widget.getwarmly.com/warmly.js?clientId=4819f621f434715d064bd2650e7e8f24" defer></script>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)