### PR TITLE
Fixes evaluation of true/false on radio button, which are both passed as strings.

### DIFF
--- a/components/security-issues/SecurityIssueDetail.tsx
+++ b/components/security-issues/SecurityIssueDetail.tsx
@@ -131,7 +131,7 @@ export const SecurityIssueDetail: FC<{
               Requires Admin:
             </TableHead>
             <TableCell className="text-base leading-7 text-foreground px-4 border-border border-r last:border-r-0">
-              {issue.requiresAdminAccess ? "Yes" : "No"}
+              {issue.requiresAdminAccess === "true" ? "Yes" : "No"}
             </TableCell>
           </TableRow>
           <TableRow>


### PR DESCRIPTION
I.e., a value of `"false"` still evaluates as `true`. Not a good way for a security issue to behave!