### PR TITLE
Changes docImage replacement pattern to use inodes instead of identifier

### DIFF
--- a/components/documentation/Documentation.js
+++ b/components/documentation/Documentation.js
@@ -12,13 +12,7 @@ import Warn from "../mdx/Warn";
 import Info from "../mdx/Info";
 import getDeprecations from "@/services/docs/getDeprecations/getDeprecations";
 import { DeprecationCard } from "../deprecations/DeprecationCard";
-
-
-function cleanMarkdown(markdownString, identifierString) {
-  return markdownString
-    .replaceAll("${docImage}", "/dA/" + identifierString + "/diagram")
-    .replaceAll("</br>", "<br>");
-}
+import { cleanMarkdown } from "./cleanMarkdown";
 
 const Documentation = ({ contentlet, sideNav, slug, deprecation }) => {
   const { open: assistantOpen, expanded: assistantExpanded } = useAssistant();
@@ -36,7 +30,7 @@ const Documentation = ({ contentlet, sideNav, slug, deprecation }) => {
 
   const documentation = cleanMarkdown(
     contentlet.documentation,
-    contentlet.identifier
+    contentlet.inode
   );
 
   return (

--- a/components/documentation/DocumentationComponent.tsx
+++ b/components/documentation/DocumentationComponent.tsx
@@ -3,15 +3,7 @@
 
 import MarkdownContent from "@/components/MarkdownContent";
 import Warn from "../mdx/Warn";
-
-function cleanMarkdown(markdownString: string | undefined | null, identifierString: string) {
-  if (!markdownString) {
-    return "";
-  }
-  return markdownString
-    .replaceAll("${docImage}", "/dA/" + identifierString + "/diagram")
-    .replaceAll("</br>", "<br>");
-}
+import { cleanMarkdown } from "./cleanMarkdown";
 
 export default function DocumentationComponent(contentlet: any ) {
 
@@ -21,7 +13,7 @@ export default function DocumentationComponent(contentlet: any ) {
 
   const documentation = cleanMarkdown(
     contentlet.documentation,
-    contentlet.identifier
+    contentlet.inode
   );
 
   return (

--- a/components/documentation/cleanMarkdown.ts
+++ b/components/documentation/cleanMarkdown.ts
@@ -1,0 +1,11 @@
+export function cleanMarkdown(
+  markdownString: string | undefined | null,
+  inodeString: string
+) {
+  if (!markdownString) {
+    return "";
+  }
+  return markdownString
+    .replaceAll("${docImage}", "/dA/" + inodeString + "/diagram")
+    .replaceAll("</br>", "<br>");
+}


### PR DESCRIPTION
It also refactors the replacement pattern slightly, breaking it out of two places to use as a shared component, to avoid needless repeating of oneself!