### PR TITLE
Fixing LTS patch releases to use the parent EOL dates

### DIFF
--- a/components/changelogs/ChangeLogList.js
+++ b/components/changelogs/ChangeLogList.js
@@ -141,10 +141,11 @@ export default function ChangeLogContainer({ sideNav, slug }) {
                 const ltsMajorVersions = []; // list of LTS major versions
                 const ltsEol = []; // list of boolean values indicating if the LTS version has reached EOL
                 const pastEol = (eol) => { return new Date(eol) < new Date(); }
+                const resolveLineMetadata = (item) => item.parent || item;
                 for (const item of data.ltsMajors) { // iterate over the LTS major versions
                   for (const vTag of item.tags) { // check tags
                     if (/^\d/.test(vTag) && !ltsMajorVersions.includes(vTag)) { // if tag designates a major LTS version
-                      const eol = new Date(item.eolDate);
+                      const eol = new Date(resolveLineMetadata(item).eolDate);
                       ltsMajorVersions.push(vTag); // store tag
                       ltsEol.push(pastEol(eol)) // store EOL status
                       break;
@@ -169,8 +170,7 @@ export default function ChangeLogContainer({ sideNav, slug }) {
                 // just to convey the Designation/EOL dates for the entire page
                 const vLtsIndex = ltsMajorVersions.indexOf(vLts);
                 if (vLtsIndex !== -1 && data.ltsMajors && data.ltsMajors[vLtsIndex]) {
-                  thisMajorVersion = data.ltsMajors[vLtsIndex].parent ? 
-                    data.ltsMajors[vLtsIndex].parent : data.ltsMajors[vLtsIndex];
+                  thisMajorVersion = resolveLineMetadata(data.ltsMajors[vLtsIndex]);
                 } else {
                   thisMajorVersion = null;
                 }

--- a/components/releases/TableReleases/TableReleases.tsx
+++ b/components/releases/TableReleases/TableReleases.tsx
@@ -39,8 +39,11 @@ export const TableReleases: FC<{
   const {data: regularReleases, loading, error} = useReleases(limit, currentPage, filter, false, version);
   const pagination = showCurrent ? {} : regularReleases?.pagination;
   
+  const getEffectiveEolDate = (release: { eolDate: string; parent?: { eolDate?: string } }) =>
+    release.parent?.eolDate || release.eolDate;
+
   const releaseMap = currentReleases.reduce((acc, release) => {
-    acc[release.minor] = {version: release.minor, lts: release.lts, eolDate: release.eolDate, isLatest: release.lts === "3"};
+    acc[release.minor] = {version: release.minor, lts: release.lts, eolDate: getEffectiveEolDate(release), isLatest: release.lts === "3"};
     return acc;
   }, {} as Record<string, {version: string, lts: string, eolDate: string, isLatest: boolean}>);
 
@@ -118,13 +121,15 @@ export const TableReleases: FC<{
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-800">
-            {filteredReleases.map((release, index) => (
+            {filteredReleases.map((release, index) => {
+              const effectiveEolDate = getEffectiveEolDate(release);
+              return (
               <tr 
                 key={`lts-${index}-${release.minor}`} 
                 className={`transition-colors ${
-                    releaseMap[release.minor] && !isEolPassed(release.eolDate)?
+                    releaseMap[release.minor] && !isEolPassed(effectiveEolDate)?
                     'bg-green-100 dark:bg-gray-700/50 hover:bg-gray-200 dark:hover:bg-gray-700'
-                   : isEolPassed(release.eolDate)
+                   : isEolPassed(effectiveEolDate)
                     ? 'bg-gray-100 dark:bg-gray-700/50 hover:bg-gray-200 dark:hover:bg-gray-700'
                     : 'hover:bg-gray-50 dark:hover:bg-gray-700'
                 }`}
@@ -223,12 +228,13 @@ export const TableReleases: FC<{
                   {extractDateForTables(release.releasedDate)}
                 </td>
                 {showLtsColumn && (   
-                <td className={`px-6 py-4 text-sm text-gray-500 dark:text-gray-400 text-center text-nowrap font-mono ${isEolPassed(release.eolDate) ? 'line-through' : ''}`}>
-                  {release.lts === "3" ? "-" : extractDateForTables(release.eolDate)}
+                <td className={`px-6 py-4 text-sm text-gray-500 dark:text-gray-400 text-center text-nowrap font-mono ${isEolPassed(effectiveEolDate) ? 'line-through' : ''}`}>
+                  {release.lts === "3" ? "-" : extractDateForTables(effectiveEolDate)}
                 </td>
                 )}
               </tr>
-            ))}
+            );
+            })}
           </tbody>
         </table>
         {!showCurrent && (

--- a/hooks/useReleases.ts
+++ b/hooks/useReleases.ts
@@ -14,7 +14,10 @@ interface ReleaseData {
 const filterCurrentReleases = (releases: any[]) => {
 
     const latestCurrent = releases.filter((release) => release.lts === "3")[0];
-    const latestLtses = releases.filter((release) => release.lts === "1" && new Date(release.eolDate) > new Date());
+    const latestLtses = releases.filter((release) => {
+      const eolDate = release.parent?.eolDate || release.eolDate;
+      return release.lts === "1" && new Date(eolDate) > new Date();
+    });
     const versions: typeof latestLtses = [];
 
     const ltsesMap = new Map();


### PR DESCRIPTION
All Releases and Current Releases pages were displaying the inherited LTS EOL dates on patches, when it should have been showing the parent-content's EOL date. The v0 release should be the single source of truth on this, and now it will go back to being such.

*Edit with more detailed summary for bookkeeping:*

## Summary

Fixes incorrect EOL dates shown for LTS releases on the docs site. A visitor reported that Warmly stated 25.07 LTS is supported through March 31, 2027, while `/docs/all-releases` showed January 2027.

**Root cause:** In dotCMS, individual LTS builds (latest and patch releases) often carry a stale `eolDate` on the build record itself. The authoritative EOL is stored on the parent **v0 designation record** (`parent.eolDate`). The changelog header already resolved this via `parent`, but the All Releases and Current Releases pages did not.

**CMS model (for context):**
- `lts:1` = latest build in an LTS line
- `lts:2` = not latest (older patches and the v0 designation record)
- `lts:3` = non-LTS / current
- Tag strings (e.g. `25.07.10-1`) identify an LTS line; builds in that line point to the same parent v0 record for designation/EOL metadata

**Example (25.07):** Latest build `25.07.10-1v12` has own EOL `2027-01-18`, but parent `25.07.10-1v0` has EOL `2027-03-31`.

### Changes

- **`TableReleases.tsx`** — Added `getEffectiveEolDate()` (`parent?.eolDate || eolDate`) for EOL column display, past-EOL row styling, and the current-releases lookup map. Fixes `/docs/all-releases` and `/docs/current-releases`.
- **`useReleases.ts`** — Apply parent EOL when filtering active LTS lines for the Current Releases page.
- **`ChangeLogList.js`** — Added `resolveLineMetadata()` (`item.parent || item`) so the LTS version dropdown's "Past EOL" label uses the same authoritative EOL as the page header.

### Audit notes

- Searched the codebase for other raw `eolDate` usages; no other live UI paths needed changes.
- Non-LTS releases (`lts:3`) have no parent; the fallback to own `eolDate` is unchanged.
- `getReleases` / `getChangelog` already fetch `parent { eolDate }`; no API changes required.
